### PR TITLE
Add permissions field to users

### DIFF
--- a/db/migrations/001_init.sql
+++ b/db/migrations/001_init.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS users (
     phone VARCHAR(30) NOT NULL,
     password VARCHAR(255) NOT NULL,
     role VARCHAR(50) NOT NULL,
+    permissions TEXT,
     salary_hookah DOUBLE DEFAULT 0,
     salary_bar DOUBLE DEFAULT 0,
     salary_shift INT DEFAULT 0,

--- a/db/migrations/003_user_permissions.sql
+++ b/db/migrations/003_user_permissions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN permissions TEXT;

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -8,6 +8,7 @@ type User struct {
 	Phone        string    `json:"phone"`
 	Password     string    `json:"-"`
 	Role         string    `json:"role"`
+	Permissions  []string  `json:"permissions"`
 	SalaryHookah float64   `json:"salary_hookah"`
 	SalaryBar    float64   `json:"salary_bar"`
 	SalaryShift  int       `json:"salary_shift"`

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -53,6 +53,10 @@ func (s *AuthService) Register(ctx context.Context, u *models.User) (string, str
 	if existing != nil {
 		return "", "", errors.New("user already exists")
 	}
+	if u.Role == "admin" && len(u.Permissions) == 0 {
+		u.Permissions = []string{"bar", "hookah", "sets"}
+	}
+
 	hashed, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
## Summary
- add `Permissions` field to user model
- include permissions column in schema and migrations
- support permissions in user repository and default admin permissions in auth service

## Testing
- `go test ./...` *(fails: fetching dependencies blocked)*
- `go vet ./...` *(fails: fetching dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ffbfbb7a4832485f4a68155bcc28f