### PR TITLE
Add user filtering for report endpoints

### DIFF
--- a/internal/handlers/report_handler.go
+++ b/internal/handlers/report_handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"psclub-crm/internal/services"
+	"strconv"
 	"time"
 )
 
@@ -17,7 +18,8 @@ func NewReportHandler(service *services.ReportService) *ReportHandler {
 
 func (h *ReportHandler) GetSummaryReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.SummaryReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.SummaryReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -27,7 +29,8 @@ func (h *ReportHandler) GetSummaryReport(c *gin.Context) {
 
 func (h *ReportHandler) GetAdminsReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.AdminsReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.AdminsReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -37,7 +40,8 @@ func (h *ReportHandler) GetAdminsReport(c *gin.Context) {
 
 func (h *ReportHandler) GetSalesReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.SalesReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.SalesReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -47,7 +51,8 @@ func (h *ReportHandler) GetSalesReport(c *gin.Context) {
 
 func (h *ReportHandler) GetAnalyticsReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.AnalyticsReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.AnalyticsReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -57,7 +62,8 @@ func (h *ReportHandler) GetAnalyticsReport(c *gin.Context) {
 
 func (h *ReportHandler) GetDiscountsReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.DiscountsReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.DiscountsReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -72,4 +78,16 @@ func getPeriod(c *gin.Context) (from, to time.Time) {
 	from, _ = time.Parse(layout, fromStr)
 	to, _ = time.Parse(layout, toStr)
 	return from, to
+}
+
+func getUserID(c *gin.Context) int {
+	userStr := c.DefaultQuery("user_id", "all")
+	if userStr == "all" {
+		return 0
+	}
+	id, err := strconv.Atoi(userStr)
+	if err != nil {
+		return 0
+	}
+	return id
 }

--- a/internal/services/report_service.go
+++ b/internal/services/report_service.go
@@ -15,18 +15,18 @@ func NewReportService(repo *repositories.ReportRepository) *ReportService {
 	return &ReportService{repo: repo}
 }
 
-func (s *ReportService) SummaryReport(ctx context.Context, from, to time.Time) (*models.SummaryReport, error) {
-	return s.repo.SummaryReport(ctx, from, to)
+func (s *ReportService) SummaryReport(ctx context.Context, from, to time.Time, userID int) (*models.SummaryReport, error) {
+	return s.repo.SummaryReport(ctx, from, to, userID)
 }
-func (s *ReportService) AdminsReport(ctx context.Context, from, to time.Time) (*models.AdminsReport, error) {
-	return s.repo.AdminsReport(ctx, from, to)
+func (s *ReportService) AdminsReport(ctx context.Context, from, to time.Time, userID int) (*models.AdminsReport, error) {
+	return s.repo.AdminsReport(ctx, from, to, userID)
 }
-func (s *ReportService) SalesReport(ctx context.Context, from, to time.Time) (*models.SalesReport, error) {
-	return s.repo.SalesReport(ctx, from, to)
+func (s *ReportService) SalesReport(ctx context.Context, from, to time.Time, userID int) (*models.SalesReport, error) {
+	return s.repo.SalesReport(ctx, from, to, userID)
 }
-func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time) (*models.AnalyticsReport, error) {
-	return s.repo.AnalyticsReport(ctx, from, to)
+func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time, userID int) (*models.AnalyticsReport, error) {
+	return s.repo.AnalyticsReport(ctx, from, to, userID)
 }
-func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time) (*models.DiscountsReport, error) {
-	return s.repo.DiscountsReport(ctx, from, to)
+func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time, userID int) (*models.DiscountsReport, error) {
+	return s.repo.DiscountsReport(ctx, from, to, userID)
 }


### PR DESCRIPTION
## Summary
- allow `user_id` query param for all report handlers
- plumb user filter through service and repository layers
- update report repository queries to optionally filter bookings by user

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68519ffdb5a48324aa2161aed0fcea5e