### PR TITLE
Add user filtering for report endpoints

### DIFF
--- a/internal/handlers/price_item_handler.go
+++ b/internal/handlers/price_item_handler.go
@@ -41,6 +41,20 @@ func (h *PriceItemHandler) GetAllPriceItems(c *gin.Context) {
 	c.JSON(http.StatusOK, items)
 }
 
+func (h *PriceItemHandler) GetPriceItemsByCategory(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	items, err := h.service.GetPriceItemsByCategory(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, items)
+}
+
 func (h *PriceItemHandler) GetPriceItemByID(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {

--- a/internal/handlers/report_handler.go
+++ b/internal/handlers/report_handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"psclub-crm/internal/services"
+	"strconv"
 	"time"
 )
 
@@ -17,7 +18,8 @@ func NewReportHandler(service *services.ReportService) *ReportHandler {
 
 func (h *ReportHandler) GetSummaryReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.SummaryReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.SummaryReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -27,7 +29,8 @@ func (h *ReportHandler) GetSummaryReport(c *gin.Context) {
 
 func (h *ReportHandler) GetAdminsReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.AdminsReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.AdminsReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -37,7 +40,8 @@ func (h *ReportHandler) GetAdminsReport(c *gin.Context) {
 
 func (h *ReportHandler) GetSalesReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.SalesReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.SalesReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -47,7 +51,8 @@ func (h *ReportHandler) GetSalesReport(c *gin.Context) {
 
 func (h *ReportHandler) GetAnalyticsReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.AnalyticsReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.AnalyticsReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -57,7 +62,8 @@ func (h *ReportHandler) GetAnalyticsReport(c *gin.Context) {
 
 func (h *ReportHandler) GetDiscountsReport(c *gin.Context) {
 	from, to := getPeriod(c)
-	data, err := h.service.DiscountsReport(c.Request.Context(), from, to)
+	userID := getUserID(c)
+	data, err := h.service.DiscountsReport(c.Request.Context(), from, to, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -72,4 +78,16 @@ func getPeriod(c *gin.Context) (from, to time.Time) {
 	from, _ = time.Parse(layout, fromStr)
 	to, _ = time.Parse(layout, toStr)
 	return from, to
+}
+
+func getUserID(c *gin.Context) int {
+	userStr := c.DefaultQuery("user_id", "all")
+	if userStr == "all" {
+		return 0
+	}
+	id, err := strconv.Atoi(userStr)
+	if err != nil {
+		return 0
+	}
+	return id
 }

--- a/internal/repositories/price_item_repository.go
+++ b/internal/repositories/price_item_repository.go
@@ -88,3 +88,28 @@ func (r *PriceItemRepository) DecreaseStock(ctx context.Context, id int, amount 
 	}
 	return nil
 }
+
+func (r *PriceItemRepository) GetByCategory(ctx context.Context, categoryID int) ([]models.PriceItem, error) {
+	query := `SELECT id, name, category_id, subcategory_id, quantity, sale_price, buy_price, is_set
+                FROM price_items WHERE category_id = ? ORDER BY id`
+	rows, err := r.db.QueryContext(ctx, query, categoryID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var list []models.PriceItem
+	for rows.Next() {
+		var p models.PriceItem
+		if err := rows.Scan(&p.ID, &p.Name, &p.CategoryID, &p.SubcategoryID, &p.Quantity, &p.SalePrice, &p.BuyPrice, &p.IsSet); err != nil {
+			return nil, err
+		}
+		list = append(list, p)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return list, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -99,6 +99,7 @@ func SetupRoutes(
 	{
 		pricelist.POST("", priceListHandler.CreatePriceItem)
 		pricelist.GET("", priceListHandler.GetAllPriceItems)
+		pricelist.GET("/category/:id", priceListHandler.GetPriceItemsByCategory)
 		pricelist.GET("/:id", priceListHandler.GetPriceItemByID)
 		pricelist.PUT("/:id", priceListHandler.UpdatePriceItem)
 		pricelist.DELETE("/:id", priceListHandler.DeletePriceItem)

--- a/internal/services/price_item_service.go
+++ b/internal/services/price_item_service.go
@@ -36,6 +36,10 @@ func (s *PriceItemService) DeletePriceItem(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
 
+func (s *PriceItemService) GetPriceItemsByCategory(ctx context.Context, categoryID int) ([]models.PriceItem, error) {
+	return s.repo.GetByCategory(ctx, categoryID)
+}
+
 // Приход товара на склад — создаёт запись в истории и увеличивает остаток
 func (s *PriceItemService) AddIncome(ctx context.Context, history *models.PriceItemHistory) error {
 	if history.Operation != "INCOME" {

--- a/internal/services/report_service.go
+++ b/internal/services/report_service.go
@@ -15,18 +15,18 @@ func NewReportService(repo *repositories.ReportRepository) *ReportService {
 	return &ReportService{repo: repo}
 }
 
-func (s *ReportService) SummaryReport(ctx context.Context, from, to time.Time) (*models.SummaryReport, error) {
-	return s.repo.SummaryReport(ctx, from, to)
+func (s *ReportService) SummaryReport(ctx context.Context, from, to time.Time, userID int) (*models.SummaryReport, error) {
+	return s.repo.SummaryReport(ctx, from, to, userID)
 }
-func (s *ReportService) AdminsReport(ctx context.Context, from, to time.Time) (*models.AdminsReport, error) {
-	return s.repo.AdminsReport(ctx, from, to)
+func (s *ReportService) AdminsReport(ctx context.Context, from, to time.Time, userID int) (*models.AdminsReport, error) {
+	return s.repo.AdminsReport(ctx, from, to, userID)
 }
-func (s *ReportService) SalesReport(ctx context.Context, from, to time.Time) (*models.SalesReport, error) {
-	return s.repo.SalesReport(ctx, from, to)
+func (s *ReportService) SalesReport(ctx context.Context, from, to time.Time, userID int) (*models.SalesReport, error) {
+	return s.repo.SalesReport(ctx, from, to, userID)
 }
-func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time) (*models.AnalyticsReport, error) {
-	return s.repo.AnalyticsReport(ctx, from, to)
+func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time, userID int) (*models.AnalyticsReport, error) {
+	return s.repo.AnalyticsReport(ctx, from, to, userID)
 }
-func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time) (*models.DiscountsReport, error) {
-	return s.repo.DiscountsReport(ctx, from, to)
+func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time, userID int) (*models.DiscountsReport, error) {
+	return s.repo.DiscountsReport(ctx, from, to, userID)
 }


### PR DESCRIPTION
## Summary
- allow `user_id` query param for all report handlers
- plumb user filter through service and repository layers
- update report repository queries to optionally filter bookings by user
- add `/api/pricelist/category/:id` endpoint for fetching items by category

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68519ffdb5a48324aa2161aed0fcea5e