### PR TITLE
Add pricelist history and replenish endpoint

### DIFF
--- a/db/migrations/005_pricelist_history.up.sql
+++ b/db/migrations/005_pricelist_history.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS pricelist_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    price_item_id INT NOT NULL,
+    quantity INT NOT NULL,
+    buy_price DOUBLE NOT NULL,
+    total DOUBLE NOT NULL,
+    user_id INT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (price_item_id) REFERENCES price_items(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,7 +70,8 @@ func Run() {
 	// Прайс-лист
 	priceRepo := repositories.NewPriceItemRepository(db)
 	historyRepo := repositories.NewPriceItemHistoryRepository(db)
-	priceService := services.NewPriceItemService(priceRepo, historyRepo)
+	plHistoryRepo := repositories.NewPricelistHistoryRepository(db)
+	priceService := services.NewPriceItemService(priceRepo, historyRepo, plHistoryRepo)
 	priceHandler := handlers.NewPriceItemHandler(priceService)
 
 	// Сеты товаров

--- a/internal/models/pricelist_history.go
+++ b/internal/models/pricelist_history.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+type PricelistHistory struct {
+	ID          int       `json:"id"`
+	PriceItemID int       `json:"price_item_id"`
+	Quantity    int       `json:"quantity"`
+	BuyPrice    float64   `json:"buy_price"`
+	Total       float64   `json:"total"`
+	UserID      int       `json:"user_id"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/repositories/pricelist_history_repository.go
+++ b/internal/repositories/pricelist_history_repository.go
@@ -1,0 +1,61 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"psclub-crm/internal/models"
+)
+
+type PricelistHistoryRepository struct {
+	db *sql.DB
+}
+
+func NewPricelistHistoryRepository(db *sql.DB) *PricelistHistoryRepository {
+	return &PricelistHistoryRepository{db: db}
+}
+
+func (r *PricelistHistoryRepository) Create(ctx context.Context, h *models.PricelistHistory) (int, error) {
+	query := `INSERT INTO pricelist_history (price_item_id, quantity, buy_price, total, user_id, created_at) VALUES (?, ?, ?, ?, ?, NOW())`
+	res, err := r.db.ExecContext(ctx, query, h.PriceItemID, h.Quantity, h.BuyPrice, h.Total, h.UserID)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *PricelistHistoryRepository) GetByItem(ctx context.Context, priceItemID int) ([]models.PricelistHistory, error) {
+	query := `SELECT id, price_item_id, quantity, buy_price, total, user_id, created_at FROM pricelist_history WHERE price_item_id = ? ORDER BY id DESC`
+	rows, err := r.db.QueryContext(ctx, query, priceItemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []models.PricelistHistory
+	for rows.Next() {
+		var h models.PricelistHistory
+		if err := rows.Scan(&h.ID, &h.PriceItemID, &h.Quantity, &h.BuyPrice, &h.Total, &h.UserID, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	return result, nil
+}
+
+func (r *PricelistHistoryRepository) GetAll(ctx context.Context) ([]models.PricelistHistory, error) {
+	query := `SELECT id, price_item_id, quantity, buy_price, total, user_id, created_at FROM pricelist_history ORDER BY id DESC`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []models.PricelistHistory
+	for rows.Next() {
+		var h models.PricelistHistory
+		if err := rows.Scan(&h.ID, &h.PriceItemID, &h.Quantity, &h.BuyPrice, &h.Total, &h.UserID, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	return result, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -103,6 +103,7 @@ func SetupRoutes(
 		pricelist.GET("/:id", priceListHandler.GetPriceItemByID)
 		pricelist.PUT("/:id", priceListHandler.UpdatePriceItem)
 		pricelist.DELETE("/:id", priceListHandler.DeletePriceItem)
+		pricelist.POST("/:id/replenish", priceListHandler.Replenish)
 	}
 
 	// --- Сеты (наборы товаров)

--- a/internal/services/price_item_service.go
+++ b/internal/services/price_item_service.go
@@ -8,12 +8,13 @@ import (
 )
 
 type PriceItemService struct {
-	repo        *repositories.PriceItemRepository
-	historyRepo *repositories.PriceItemHistoryRepository
+	repo          *repositories.PriceItemRepository
+	historyRepo   *repositories.PriceItemHistoryRepository
+	plHistoryRepo *repositories.PricelistHistoryRepository
 }
 
-func NewPriceItemService(r *repositories.PriceItemRepository, hr *repositories.PriceItemHistoryRepository) *PriceItemService {
-	return &PriceItemService{repo: r, historyRepo: hr}
+func NewPriceItemService(r *repositories.PriceItemRepository, hr *repositories.PriceItemHistoryRepository, plhr *repositories.PricelistHistoryRepository) *PriceItemService {
+	return &PriceItemService{repo: r, historyRepo: hr, plHistoryRepo: plhr}
 }
 
 func (s *PriceItemService) CreatePriceItem(ctx context.Context, item *models.PriceItem) (int, error) {
@@ -74,4 +75,12 @@ func (s *PriceItemService) GetHistoryByItem(ctx context.Context, priceItemID int
 // Получить всю историю операций
 func (s *PriceItemService) GetAllHistory(ctx context.Context) ([]models.PriceItemHistory, error) {
 	return s.historyRepo.GetAll(ctx)
+}
+
+// Replenish increases stock and saves record to pricelist_history
+func (s *PriceItemService) Replenish(ctx context.Context, hist *models.PricelistHistory) error {
+	if _, err := s.plHistoryRepo.Create(ctx, hist); err != nil {
+		return err
+	}
+	return s.repo.IncreaseStock(ctx, hist.PriceItemID, hist.Quantity)
 }


### PR DESCRIPTION
## Summary
- create `pricelist_history` table
- add model and repository for new history
- allow replenishing stock and log to history
- expose POST `/api/pricelist/:id/replenish`

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851af4e57b883249b9e1f35a59b1fdc