### PR TITLE
Add pricelist history route by category

### DIFF
--- a/db/migrations/005_pricelist_history.up.sql
+++ b/db/migrations/005_pricelist_history.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS pricelist_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    price_item_id INT NOT NULL,
+    quantity INT NOT NULL,
+    buy_price DOUBLE NOT NULL,
+    total DOUBLE NOT NULL,
+    user_id INT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (price_item_id) REFERENCES price_items(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,8 +70,10 @@ func Run() {
 	// Прайс-лист
 	priceRepo := repositories.NewPriceItemRepository(db)
 	historyRepo := repositories.NewPriceItemHistoryRepository(db)
-	priceService := services.NewPriceItemService(priceRepo, historyRepo)
+	plHistoryRepo := repositories.NewPricelistHistoryRepository(db)
+	priceService := services.NewPriceItemService(priceRepo, historyRepo, plHistoryRepo)
 	priceHandler := handlers.NewPriceItemHandler(priceService)
+	plHistoryHandler := handlers.NewPricelistHistoryHandler(priceService)
 
 	// Сеты товаров
 	priceSetRepo := repositories.NewPriceSetRepository(db)
@@ -132,6 +134,7 @@ func Run() {
 		categoryHandler,
 		subCategoryHandler,
 		priceHandler,
+		plHistoryHandler,
 		priceSetHandler,
 		repairHandler,
 		cashboxHandler,

--- a/internal/handlers/pricelist_history_handler.go
+++ b/internal/handlers/pricelist_history_handler.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/services"
+	"strconv"
+)
+
+type PricelistHistoryHandler struct {
+	service *services.PriceItemService
+}
+
+func NewPricelistHistoryHandler(s *services.PriceItemService) *PricelistHistoryHandler {
+	return &PricelistHistoryHandler{service: s}
+}
+
+// POST /api/pricelist-history
+func (h *PricelistHistoryHandler) Create(c *gin.Context) {
+	var hist models.PricelistHistory
+	if err := c.ShouldBindJSON(&hist); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.service.CreatePricelistHistory(c.Request.Context(), &hist)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	hist.ID = id
+	c.JSON(http.StatusCreated, hist)
+}
+
+// GET /api/pricelist-history
+func (h *PricelistHistoryHandler) GetAll(c *gin.Context) {
+	history, err := h.service.GetAllPricelistHistory(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, history)
+}
+
+// GET /api/pricelist-history/item/:id
+func (h *PricelistHistoryHandler) GetByItem(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	history, err := h.service.GetPricelistHistoryByItem(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, history)
+}
+
+func (h *PricelistHistoryHandler) GetByCategory(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	history, err := h.service.GetPricelistHistoryByCategory(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, history)
+}

--- a/internal/models/pricelist_history.go
+++ b/internal/models/pricelist_history.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+type PricelistHistory struct {
+	ID          int       `json:"id"`
+	PriceItemID int       `json:"price_item_id"`
+	Quantity    int       `json:"quantity"`
+	BuyPrice    float64   `json:"buy_price"`
+	Total       float64   `json:"total"`
+	UserID      int       `json:"user_id"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/repositories/pricelist_history_repository.go
+++ b/internal/repositories/pricelist_history_repository.go
@@ -1,0 +1,82 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"psclub-crm/internal/models"
+)
+
+type PricelistHistoryRepository struct {
+	db *sql.DB
+}
+
+func NewPricelistHistoryRepository(db *sql.DB) *PricelistHistoryRepository {
+	return &PricelistHistoryRepository{db: db}
+}
+
+func (r *PricelistHistoryRepository) Create(ctx context.Context, h *models.PricelistHistory) (int, error) {
+	query := `INSERT INTO pricelist_history (price_item_id, quantity, buy_price, total, user_id, created_at) VALUES (?, ?, ?, ?, ?, NOW())`
+	res, err := r.db.ExecContext(ctx, query, h.PriceItemID, h.Quantity, h.BuyPrice, h.Total, h.UserID)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *PricelistHistoryRepository) GetByItem(ctx context.Context, priceItemID int) ([]models.PricelistHistory, error) {
+	query := `SELECT id, price_item_id, quantity, buy_price, total, user_id, created_at FROM pricelist_history WHERE price_item_id = ? ORDER BY id DESC`
+	rows, err := r.db.QueryContext(ctx, query, priceItemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []models.PricelistHistory
+	for rows.Next() {
+		var h models.PricelistHistory
+		if err := rows.Scan(&h.ID, &h.PriceItemID, &h.Quantity, &h.BuyPrice, &h.Total, &h.UserID, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	return result, nil
+}
+
+func (r *PricelistHistoryRepository) GetAll(ctx context.Context) ([]models.PricelistHistory, error) {
+	query := `SELECT id, price_item_id, quantity, buy_price, total, user_id, created_at FROM pricelist_history ORDER BY id DESC`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []models.PricelistHistory
+	for rows.Next() {
+		var h models.PricelistHistory
+		if err := rows.Scan(&h.ID, &h.PriceItemID, &h.Quantity, &h.BuyPrice, &h.Total, &h.UserID, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	return result, nil
+}
+
+func (r *PricelistHistoryRepository) GetByCategory(ctx context.Context, categoryID int) ([]models.PricelistHistory, error) {
+	query := `SELECT ph.id, ph.price_item_id, ph.quantity, ph.buy_price, ph.total, ph.user_id, ph.created_at
+                FROM pricelist_history ph
+                JOIN price_items pi ON ph.price_item_id = pi.id
+                WHERE pi.category_id = ? ORDER BY ph.id DESC`
+	rows, err := r.db.QueryContext(ctx, query, categoryID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []models.PricelistHistory
+	for rows.Next() {
+		var h models.PricelistHistory
+		if err := rows.Scan(&h.ID, &h.PriceItemID, &h.Quantity, &h.BuyPrice, &h.Total, &h.UserID, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	return result, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -17,6 +17,7 @@ func SetupRoutes(
 	categoryHandler *handlers.CategoryHandler,
 	subCategoryHandler *handlers.SubcategoryHandler,
 	priceListHandler *handlers.PriceItemHandler,
+	pricelistHistoryHandler *handlers.PricelistHistoryHandler,
 	priceSetHandler *handlers.PriceSetHandler,
 	repairHandler *handlers.RepairHandler,
 	cashboxHandler *handlers.CashboxHandler,
@@ -103,6 +104,7 @@ func SetupRoutes(
 		pricelist.GET("/:id", priceListHandler.GetPriceItemByID)
 		pricelist.PUT("/:id", priceListHandler.UpdatePriceItem)
 		pricelist.DELETE("/:id", priceListHandler.DeletePriceItem)
+		pricelist.POST("/:id/replenish", priceListHandler.Replenish)
 	}
 
 	// --- Сеты (наборы товаров)
@@ -113,6 +115,15 @@ func SetupRoutes(
 		sets.GET("/:id", priceSetHandler.GetPriceSetByID)
 		sets.PUT("/:id", priceSetHandler.UpdatePriceSet)
 		sets.DELETE("/:id", priceSetHandler.DeletePriceSet)
+	}
+
+	// --- История пополнений прайс-листа
+	plHistory := api.Group("/pricelist-history")
+	{
+		plHistory.POST("", pricelistHistoryHandler.Create)
+		plHistory.GET("", pricelistHistoryHandler.GetAll)
+		plHistory.GET("/item/:id", pricelistHistoryHandler.GetByItem)
+		plHistory.GET("/category/:id", pricelistHistoryHandler.GetByCategory)
 	}
 
 	//// --- История закупа (прихода на склад)


### PR DESCRIPTION
## Summary
- allow fetching pricelist history records filtered by category ID
- expose new `GetByCategory` handler at `GET /api/pricelist-history/category/:id`
- implement service and repository helpers for category-based queries

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851af4e57b883249b9e1f35a59b1fdc