### PR TITLE
Implement inventory deductions on booking

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -89,6 +89,8 @@ func Run() {
 		bookingItemRepo,
 		clientRepo,
 		settingsRepo,
+		priceRepo,
+		priceSetRepo,
 	)
 	bookingHandler := handlers.NewBookingHandler(bookingService)
 

--- a/internal/repositories/price_item_repository.go
+++ b/internal/repositories/price_item_repository.go
@@ -89,13 +89,19 @@ func (r *PriceItemRepository) DecreaseStock(ctx context.Context, id int, amount 
 	return nil
 }
 
+// SetStock overrides the current quantity with the provided value.
+func (r *PriceItemRepository) SetStock(ctx context.Context, id int, quantity int) error {
+	_, err := r.db.ExecContext(ctx, `UPDATE price_items SET quantity=? WHERE id=?`, quantity, id)
+	return err
+}
+
 func (r *PriceItemRepository) GetByCategory(ctx context.Context, categoryID int) ([]models.PriceItem, error) {
 
 	query := `SELECT pi.id, pi.name, pi.category_id, subcategory_id, quantity, sale_price, buy_price, is_set, s.name AS subcategory_name
                 FROM price_items pi
                 JOIN subcategories s ON pi.subcategory_id = s.id
                 WHERE pi.category_id = ? ORDER BY id`
-  
+
 	rows, err := r.db.QueryContext(ctx, query, categoryID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- update `BookingService` to keep set stock in sync with component items
- add `SetStock` method to `PriceItemRepository`
- add `GetByItem` lookup in `PriceSetRepository`
- ensure booking creation and update rollback on inventory errors

## Testing
- `go vet ./...` *(fails: Forbidden - no internet)*
- `go build ./...` *(fails: Forbidden - no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6851c98b73f0832490c6b203a44a422a