### PR TITLE
Fix booking item quantity handling

### DIFF
--- a/internal/handlers/booking_handler.go
+++ b/internal/handlers/booking_handler.go
@@ -25,6 +25,12 @@ func (h *BookingHandler) CreateBooking(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	for _, it := range b.Items {
+		if it.Quantity <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid item quantity"})
+			return
+		}
+	}
 	id, err := h.service.CreateBooking(c.Request.Context(), &b)
 	if err != nil {
 		log.Printf("create booking service error: %v", err)

--- a/internal/services/booking_service.go
+++ b/internal/services/booking_service.go
@@ -145,6 +145,10 @@ func (s *BookingService) decreaseStock(ctx context.Context, items []models.Booki
 
 	affected := make(map[int]struct{})
 	for _, it := range items {
+		if it.Quantity <= 0 {
+			continue
+		}
+
 		pi, err := s.priceItemRepo.GetByID(ctx, it.ItemID)
 		if err != nil {
 			s.restoreChanges(ctx, changes)


### PR DESCRIPTION
## Summary
- ignore booking items with non-positive quantity when decreasing stock
- validate booking items so quantity must be positive

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851e854f1c883248b93c6443750582e