### PR TITLE
Add time range filter for reports

### DIFF
--- a/internal/handlers/report_handler.go
+++ b/internal/handlers/report_handler.go
@@ -17,9 +17,9 @@ func NewReportHandler(service *services.ReportService) *ReportHandler {
 }
 
 func (h *ReportHandler) GetSummaryReport(c *gin.Context) {
-	from, to := getPeriod(c)
+	from, to, tFrom, tTo := getPeriod(c)
 	userID := getUserID(c)
-	data, err := h.service.SummaryReport(c.Request.Context(), from, to, userID)
+	data, err := h.service.SummaryReport(c.Request.Context(), from, to, tFrom, tTo, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -28,9 +28,9 @@ func (h *ReportHandler) GetSummaryReport(c *gin.Context) {
 }
 
 func (h *ReportHandler) GetAdminsReport(c *gin.Context) {
-	from, to := getPeriod(c)
+	from, to, tFrom, tTo := getPeriod(c)
 	userID := getUserID(c)
-	data, err := h.service.AdminsReport(c.Request.Context(), from, to, userID)
+	data, err := h.service.AdminsReport(c.Request.Context(), from, to, tFrom, tTo, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -39,9 +39,9 @@ func (h *ReportHandler) GetAdminsReport(c *gin.Context) {
 }
 
 func (h *ReportHandler) GetSalesReport(c *gin.Context) {
-	from, to := getPeriod(c)
+	from, to, tFrom, tTo := getPeriod(c)
 	userID := getUserID(c)
-	data, err := h.service.SalesReport(c.Request.Context(), from, to, userID)
+	data, err := h.service.SalesReport(c.Request.Context(), from, to, tFrom, tTo, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -50,9 +50,9 @@ func (h *ReportHandler) GetSalesReport(c *gin.Context) {
 }
 
 func (h *ReportHandler) GetAnalyticsReport(c *gin.Context) {
-	from, to := getPeriod(c)
+	from, to, tFrom, tTo := getPeriod(c)
 	userID := getUserID(c)
-	data, err := h.service.AnalyticsReport(c.Request.Context(), from, to, userID)
+	data, err := h.service.AnalyticsReport(c.Request.Context(), from, to, tFrom, tTo, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -61,9 +61,9 @@ func (h *ReportHandler) GetAnalyticsReport(c *gin.Context) {
 }
 
 func (h *ReportHandler) GetDiscountsReport(c *gin.Context) {
-	from, to := getPeriod(c)
+	from, to, tFrom, tTo := getPeriod(c)
 	userID := getUserID(c)
-	data, err := h.service.DiscountsReport(c.Request.Context(), from, to, userID)
+	data, err := h.service.DiscountsReport(c.Request.Context(), from, to, tFrom, tTo, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -71,13 +71,15 @@ func (h *ReportHandler) GetDiscountsReport(c *gin.Context) {
 	c.JSON(http.StatusOK, data)
 }
 
-func getPeriod(c *gin.Context) (from, to time.Time) {
-	layout := "2006-01-02"
-	fromStr := c.DefaultQuery("from", time.Now().AddDate(0, 0, -7).Format(layout))
-	toStr := c.DefaultQuery("to", time.Now().Format(layout))
-	from, _ = time.Parse(layout, fromStr)
-	to, _ = time.Parse(layout, toStr)
-	return from, to
+func getPeriod(c *gin.Context) (from, to time.Time, tFrom, tTo string) {
+	layoutDate := "2006-01-02"
+	fromStr := c.DefaultQuery("from", time.Now().AddDate(0, 0, -7).Format(layoutDate))
+	toStr := c.DefaultQuery("to", time.Now().Format(layoutDate))
+	tFrom = c.DefaultQuery("time_from", "00:00")
+	tTo = c.DefaultQuery("time_to", "23:59:59")
+	from, _ = time.Parse(layoutDate, fromStr)
+	to, _ = time.Parse(layoutDate, toStr)
+	return from, to, tFrom, tTo
 }
 
 func getUserID(c *gin.Context) int {

--- a/internal/services/report_service.go
+++ b/internal/services/report_service.go
@@ -15,18 +15,18 @@ func NewReportService(repo *repositories.ReportRepository) *ReportService {
 	return &ReportService{repo: repo}
 }
 
-func (s *ReportService) SummaryReport(ctx context.Context, from, to time.Time, userID int) (*models.SummaryReport, error) {
-	return s.repo.SummaryReport(ctx, from, to, userID)
+func (s *ReportService) SummaryReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID int) (*models.SummaryReport, error) {
+	return s.repo.SummaryReport(ctx, from, to, tFrom, tTo, userID)
 }
-func (s *ReportService) AdminsReport(ctx context.Context, from, to time.Time, userID int) (*models.AdminsReport, error) {
-	return s.repo.AdminsReport(ctx, from, to, userID)
+func (s *ReportService) AdminsReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID int) (*models.AdminsReport, error) {
+	return s.repo.AdminsReport(ctx, from, to, tFrom, tTo, userID)
 }
-func (s *ReportService) SalesReport(ctx context.Context, from, to time.Time, userID int) (*models.SalesReport, error) {
-	return s.repo.SalesReport(ctx, from, to, userID)
+func (s *ReportService) SalesReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID int) (*models.SalesReport, error) {
+	return s.repo.SalesReport(ctx, from, to, tFrom, tTo, userID)
 }
-func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time, userID int) (*models.AnalyticsReport, error) {
-	return s.repo.AnalyticsReport(ctx, from, to, userID)
+func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID int) (*models.AnalyticsReport, error) {
+	return s.repo.AnalyticsReport(ctx, from, to, tFrom, tTo, userID)
 }
-func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time, userID int) (*models.DiscountsReport, error) {
-	return s.repo.DiscountsReport(ctx, from, to, userID)
+func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID int) (*models.DiscountsReport, error) {
+	return s.repo.DiscountsReport(ctx, from, to, tFrom, tTo, userID)
 }


### PR DESCRIPTION
## Summary
- allow specifying `time_from` and `time_to` query parameters for report endpoints
- pass time range through service layer to repository
- filter `created_at` fields by date and time in SQL queries

## Testing
- `go build ./...` *(fails: forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_685261579e608324a974e36e25c59bcb