### PR TITLE
Add create/delete settings and payment type CRUD

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -67,6 +67,11 @@ func Run() {
 	subCategoryService := services.NewSubcategoryService(subCategoryRepo)
 	subCategoryHandler := handlers.NewSubcategoryHandler(subCategoryService)
 
+	// Payment types
+	paymentTypeRepo := repositories.NewPaymentTypeRepository(db)
+	paymentTypeService := services.NewPaymentTypeService(paymentTypeRepo)
+	paymentTypeHandler := handlers.NewPaymentTypeHandler(paymentTypeService)
+
 	// Прайс-лист
 	priceRepo := repositories.NewPriceItemRepository(db)
 	historyRepo := repositories.NewPriceItemHistoryRepository(db)
@@ -135,6 +140,7 @@ func Run() {
 		bookingHandler,
 		categoryHandler,
 		subCategoryHandler,
+		paymentTypeHandler,
 		priceHandler,
 		plHistoryHandler,
 		priceSetHandler,

--- a/internal/handlers/payment_type_handler.go
+++ b/internal/handlers/payment_type_handler.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/services"
+)
+
+type PaymentTypeHandler struct {
+	service *services.PaymentTypeService
+}
+
+func NewPaymentTypeHandler(s *services.PaymentTypeService) *PaymentTypeHandler {
+	return &PaymentTypeHandler{service: s}
+}
+
+// POST /api/payment-types
+func (h *PaymentTypeHandler) CreatePaymentType(c *gin.Context) {
+	var pt models.PaymentType
+	if err := c.ShouldBindJSON(&pt); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.service.CreatePaymentType(c.Request.Context(), &pt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	pt.ID = id
+	c.JSON(http.StatusCreated, pt)
+}
+
+// GET /api/payment-types
+func (h *PaymentTypeHandler) GetAllPaymentTypes(c *gin.Context) {
+	pts, err := h.service.GetAllPaymentTypes(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, pts)
+}
+
+// PUT /api/payment-types/:id
+func (h *PaymentTypeHandler) UpdatePaymentType(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var pt models.PaymentType
+	if err := c.ShouldBindJSON(&pt); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	pt.ID = id
+	if err := h.service.UpdatePaymentType(c.Request.Context(), &pt); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, pt)
+}
+
+// DELETE /api/payment-types/:id
+func (h *PaymentTypeHandler) DeletePaymentType(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.service.DeletePaymentType(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/settings_handler.go
+++ b/internal/handlers/settings_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
+	"strconv"
 )
 
 type SettingsHandler struct {
@@ -38,4 +39,35 @@ func (h *SettingsHandler) UpdateSettings(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, set)
+}
+
+// POST /api/settings
+func (h *SettingsHandler) CreateSettings(c *gin.Context) {
+	var set models.Settings
+	if err := c.ShouldBindJSON(&set); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.service.CreateSettings(c.Request.Context(), &set)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	set.ID = id
+	c.JSON(http.StatusCreated, set)
+}
+
+// DELETE /api/settings/:id
+func (h *SettingsHandler) DeleteSettings(c *gin.Context) {
+	idParam := c.Param("id")
+	id, err := strconv.Atoi(idParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.service.DeleteSettings(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }

--- a/internal/repositories/payment_type_repository.go
+++ b/internal/repositories/payment_type_repository.go
@@ -1,0 +1,53 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"psclub-crm/internal/models"
+)
+
+// PaymentTypeRepository handles CRUD operations for payment types.
+type PaymentTypeRepository struct {
+	db *sql.DB
+}
+
+func NewPaymentTypeRepository(db *sql.DB) *PaymentTypeRepository {
+	return &PaymentTypeRepository{db: db}
+}
+
+func (r *PaymentTypeRepository) GetAll(ctx context.Context) ([]models.PaymentType, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, name FROM payment_types ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.PaymentType
+	for rows.Next() {
+		var pt models.PaymentType
+		if err := rows.Scan(&pt.ID, &pt.Name); err != nil {
+			return nil, err
+		}
+		result = append(result, pt)
+	}
+	return result, nil
+}
+
+func (r *PaymentTypeRepository) Create(ctx context.Context, pt *models.PaymentType) (int, error) {
+	res, err := r.db.ExecContext(ctx, `INSERT INTO payment_types (name) VALUES (?)`, pt.Name)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *PaymentTypeRepository) Update(ctx context.Context, pt *models.PaymentType) error {
+	_, err := r.db.ExecContext(ctx, `UPDATE payment_types SET name=? WHERE id=?`, pt.Name, pt.ID)
+	return err
+}
+
+func (r *PaymentTypeRepository) Delete(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM payment_types WHERE id=?`, id)
+	return err
+}

--- a/internal/repositories/settings_repository.go
+++ b/internal/repositories/settings_repository.go
@@ -60,3 +60,24 @@ func (r *SettingsRepository) Update(ctx context.Context, s *models.Settings) err
 	_, err := r.db.ExecContext(ctx, query, s.PaymentType, s.BlockTime, s.BonusPercent, s.WorkTimeFrom, s.WorkTimeTo, s.ID)
 	return err
 }
+
+func (r *SettingsRepository) Create(ctx context.Context, s *models.Settings) (int, error) {
+	query := `
+                INSERT INTO settings (payment_type, block_time, bonus_percent, work_time_from, work_time_to)
+                VALUES (?, ?, ?, ?, ?)
+        `
+	res, err := r.db.ExecContext(ctx, query, s.PaymentType, s.BlockTime, s.BonusPercent, s.WorkTimeFrom, s.WorkTimeTo)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return int(id), nil
+}
+
+func (r *SettingsRepository) Delete(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM settings WHERE id=?`, id)
+	return err
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -16,6 +16,7 @@ func SetupRoutes(
 	bookingHandler *handlers.BookingHandler,
 	categoryHandler *handlers.CategoryHandler,
 	subCategoryHandler *handlers.SubcategoryHandler,
+	paymentTypeHandler *handlers.PaymentTypeHandler,
 	priceListHandler *handlers.PriceItemHandler,
 	pricelistHistoryHandler *handlers.PricelistHistoryHandler,
 	priceSetHandler *handlers.PriceSetHandler,
@@ -93,6 +94,15 @@ func SetupRoutes(
 		subcategories.GET("/category/:id", subCategoryHandler.GetSubcategoryByCategoryID)
 		subcategories.PUT("/:id", subCategoryHandler.UpdateSubcategory)
 		subcategories.DELETE("/:id", subCategoryHandler.DeleteSubcategory)
+	}
+
+	// --- Типы оплат
+	paymentTypes := api.Group("/payment-types")
+	{
+		paymentTypes.POST("", paymentTypeHandler.CreatePaymentType)
+		paymentTypes.GET("", paymentTypeHandler.GetAllPaymentTypes)
+		paymentTypes.PUT("/:id", paymentTypeHandler.UpdatePaymentType)
+		paymentTypes.DELETE("/:id", paymentTypeHandler.DeletePaymentType)
 	}
 
 	// --- Прайс-лист (товары/услуги)
@@ -179,8 +189,10 @@ func SetupRoutes(
 	// --- Глобальные настройки
 	settings := api.Group("/settings")
 	{
+		settings.POST("", settingsHandler.CreateSettings)
 		settings.GET("", settingsHandler.GetSettings)
 		settings.PUT("/:id", settingsHandler.UpdateSettings)
+		settings.DELETE("/:id", settingsHandler.DeleteSettings)
 	}
 
 	// --- Отчёты (фильтрация по периодам через query-параметры)

--- a/internal/services/payment_type_service.go
+++ b/internal/services/payment_type_service.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"context"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/repositories"
+)
+
+// PaymentTypeService provides business logic for payment types.
+type PaymentTypeService struct {
+	repo *repositories.PaymentTypeRepository
+}
+
+func NewPaymentTypeService(r *repositories.PaymentTypeRepository) *PaymentTypeService {
+	return &PaymentTypeService{repo: r}
+}
+
+func (s *PaymentTypeService) GetAllPaymentTypes(ctx context.Context) ([]models.PaymentType, error) {
+	return s.repo.GetAll(ctx)
+}
+
+func (s *PaymentTypeService) CreatePaymentType(ctx context.Context, pt *models.PaymentType) (int, error) {
+	return s.repo.Create(ctx, pt)
+}
+
+func (s *PaymentTypeService) UpdatePaymentType(ctx context.Context, pt *models.PaymentType) error {
+	return s.repo.Update(ctx, pt)
+}
+
+func (s *PaymentTypeService) DeletePaymentType(ctx context.Context, id int) error {
+	return s.repo.Delete(ctx, id)
+}

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -21,3 +21,11 @@ func (s *SettingsService) GetSettings(ctx context.Context) (*models.Settings, er
 func (s *SettingsService) UpdateSettings(ctx context.Context, set *models.Settings) error {
 	return s.repo.Update(ctx, set)
 }
+
+func (s *SettingsService) CreateSettings(ctx context.Context, set *models.Settings) (int, error) {
+	return s.repo.Create(ctx, set)
+}
+
+func (s *SettingsService) DeleteSettings(ctx context.Context, id int) error {
+	return s.repo.Delete(ctx, id)
+}


### PR DESCRIPTION
## Summary
- add create and delete endpoints for settings
- implement CRUD logic for payment types with handler, service, and repository
- register payment type routes and wire new handler in app setup

## Testing
- `go build ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852b580af8083248003b953d16b20f0