### PR TITLE
Implement expenses on replenish and repair

### DIFF
--- a/db/migrations/006_remove_color_from_repairs.up.sql
+++ b/db/migrations/006_remove_color_from_repairs.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repairs DROP COLUMN color;

--- a/db/migrations/007_expense_categories.up.sql
+++ b/db/migrations/007_expense_categories.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS expense_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+ALTER TABLE expenses
+    ADD COLUMN category_id INT,
+    ADD COLUMN paid TINYINT(1) DEFAULT 0,
+    ADD FOREIGN KEY (category_id) REFERENCES expense_categories(id) ON DELETE SET NULL;

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -77,8 +77,6 @@ func Run() {
 	historyRepo := repositories.NewPriceItemHistoryRepository(db)
 	plHistoryRepo := repositories.NewPricelistHistoryRepository(db)
 	priceService := services.NewPriceItemService(priceRepo, historyRepo, plHistoryRepo)
-	priceHandler := handlers.NewPriceItemHandler(priceService)
-	plHistoryHandler := handlers.NewPricelistHistoryHandler(priceService)
 
 	// Сеты товаров
 	priceSetRepo := repositories.NewPriceSetRepository(db)
@@ -99,15 +97,23 @@ func Run() {
 	)
 	bookingHandler := handlers.NewBookingHandler(bookingService)
 
-	// Расходы
+	// Категории расходов и сами расходы
+	expCatRepo := repositories.NewExpenseCategoryRepository(db)
+	expCatService := services.NewExpenseCategoryService(expCatRepo)
+	expCatHandler := handlers.NewExpenseCategoryHandler(expCatService)
+
 	expenseRepo := repositories.NewExpenseRepository(db)
 	expenseService := services.NewExpenseService(expenseRepo)
 	expenseHandler := handlers.NewExpenseHandler(expenseService)
 
+	// Прайс-лист handlers depend on expense service
+	priceHandler := handlers.NewPriceItemHandler(priceService, expenseService)
+	plHistoryHandler := handlers.NewPricelistHistoryHandler(priceService)
+
 	// Ремонты
 	repairRepo := repositories.NewRepairRepository(db)
 	repairService := services.NewRepairService(repairRepo)
-	repairHandler := handlers.NewRepairHandler(repairService)
+	repairHandler := handlers.NewRepairHandler(repairService, expenseService)
 
 	// Касса
 	cashboxRepo := repositories.NewCashboxRepository(db)
@@ -134,6 +140,7 @@ func Run() {
 		authHandler,
 		clientHandler,
 		userHandler,
+		expCatHandler,
 		expenseHandler,
 		tableHandler,
 		tableCategoryHandler,

--- a/internal/handlers/expense_category_handler.go
+++ b/internal/handlers/expense_category_handler.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/services"
+)
+
+type ExpenseCategoryHandler struct {
+	service *services.ExpenseCategoryService
+}
+
+func NewExpenseCategoryHandler(s *services.ExpenseCategoryService) *ExpenseCategoryHandler {
+	return &ExpenseCategoryHandler{service: s}
+}
+
+func (h *ExpenseCategoryHandler) Create(c *gin.Context) {
+	var cat models.ExpenseCategory
+	if err := c.ShouldBindJSON(&cat); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.service.Create(c.Request.Context(), &cat)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	cat.ID = id
+	c.JSON(http.StatusCreated, cat)
+}
+
+func (h *ExpenseCategoryHandler) GetAll(c *gin.Context) {
+	cats, err := h.service.GetAll(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, cats)
+}
+
+func (h *ExpenseCategoryHandler) Update(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var cat models.ExpenseCategory
+	if err := c.ShouldBindJSON(&cat); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	cat.ID = id
+	if err := h.service.Update(c.Request.Context(), &cat); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, cat)
+}
+
+func (h *ExpenseCategoryHandler) Delete(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/repair_handler.go
+++ b/internal/handlers/repair_handler.go
@@ -6,14 +6,16 @@ import (
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
 	"strconv"
+	"time"
 )
 
 type RepairHandler struct {
-	service *services.RepairService
+	service  *services.RepairService
+	expenses *services.ExpenseService
 }
 
-func NewRepairHandler(s *services.RepairService) *RepairHandler {
-	return &RepairHandler{service: s}
+func NewRepairHandler(s *services.RepairService, expenseService *services.ExpenseService) *RepairHandler {
+	return &RepairHandler{service: s, expenses: expenseService}
 }
 
 // POST /api/repairs
@@ -29,6 +31,16 @@ func (h *RepairHandler) CreateRepair(c *gin.Context) {
 		return
 	}
 	rep.ID = id
+
+	exp := models.Expense{
+		Date:        time.Now(),
+		Title:       "Repair " + rep.VIN,
+		Total:       rep.Price,
+		Description: rep.Description,
+		Paid:        false,
+	}
+	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
+
 	c.JSON(http.StatusCreated, rep)
 }
 

--- a/internal/models/expense.go
+++ b/internal/models/expense.go
@@ -6,8 +6,10 @@ type Expense struct {
 	ID          int       `json:"id"`
 	Date        time.Time `json:"date"`
 	Title       string    `json:"title"`
+	CategoryID  int       `json:"category_id"`
 	Category    string    `json:"category"`
 	Total       float64   `json:"total"`
 	Description string    `json:"description"`
+	Paid        bool      `json:"paid"`
 	CreatedAt   time.Time `json:"created_at"`
 }

--- a/internal/models/expense_category.go
+++ b/internal/models/expense_category.go
@@ -1,0 +1,6 @@
+package models
+
+type ExpenseCategory struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}

--- a/internal/models/repair.go
+++ b/internal/models/repair.go
@@ -5,7 +5,6 @@ import "time"
 type Repair struct {
 	ID          int       `json:"id"`
 	Date        time.Time `json:"date"`
-	Color       string    `json:"color"`
 	VIN         string    `json:"vin"`
 	Description string    `json:"description"`
 	Price       float64   `json:"price"`

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -47,8 +47,8 @@ type UserSales struct {
 }
 
 type ExpenseTotal struct {
-	Title string  `json:"title"`
-	Total float64 `json:"total"`
+	Category string  `json:"category"`
+	Total    float64 `json:"total"`
 }
 
 type CategoryIncome struct {

--- a/internal/repositories/expense_category_repository.go
+++ b/internal/repositories/expense_category_repository.go
@@ -1,0 +1,51 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"psclub-crm/internal/models"
+)
+
+type ExpenseCategoryRepository struct {
+	db *sql.DB
+}
+
+func NewExpenseCategoryRepository(db *sql.DB) *ExpenseCategoryRepository {
+	return &ExpenseCategoryRepository{db: db}
+}
+
+func (r *ExpenseCategoryRepository) Create(ctx context.Context, c *models.ExpenseCategory) (int, error) {
+	res, err := r.db.ExecContext(ctx, `INSERT INTO expense_categories (name) VALUES (?)`, c.Name)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *ExpenseCategoryRepository) GetAll(ctx context.Context) ([]models.ExpenseCategory, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, name FROM expense_categories ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var list []models.ExpenseCategory
+	for rows.Next() {
+		var c models.ExpenseCategory
+		if err := rows.Scan(&c.ID, &c.Name); err != nil {
+			return nil, err
+		}
+		list = append(list, c)
+	}
+	return list, nil
+}
+
+func (r *ExpenseCategoryRepository) Update(ctx context.Context, c *models.ExpenseCategory) error {
+	_, err := r.db.ExecContext(ctx, `UPDATE expense_categories SET name=? WHERE id=?`, c.Name, c.ID)
+	return err
+}
+
+func (r *ExpenseCategoryRepository) Delete(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM expense_categories WHERE id=?`, id)
+	return err
+}

--- a/internal/repositories/expense_repository.go
+++ b/internal/repositories/expense_repository.go
@@ -15,8 +15,9 @@ func NewExpenseRepository(db *sql.DB) *ExpenseRepository {
 }
 
 func (r *ExpenseRepository) Create(ctx context.Context, e *models.Expense) (int, error) {
-	query := `INSERT INTO expenses (date, title, category, total, description, created_at) VALUES (?, ?, ?, ?, ?, NOW())`
-	res, err := r.db.ExecContext(ctx, query, e.Date, e.Title, e.Category, e.Total, e.Description)
+	query := `INSERT INTO expenses (date, title, category_id, total, description, paid, created_at)
+                VALUES (?, ?, NULLIF(?,0), ?, ?, ?, NOW())`
+	res, err := r.db.ExecContext(ctx, query, e.Date, e.Title, e.CategoryID, e.Total, e.Description, e.Paid)
 	if err != nil {
 		return 0, err
 	}
@@ -25,7 +26,10 @@ func (r *ExpenseRepository) Create(ctx context.Context, e *models.Expense) (int,
 }
 
 func (r *ExpenseRepository) GetAll(ctx context.Context) ([]models.Expense, error) {
-	query := `SELECT id, date, title, category, total, description, created_at FROM expenses ORDER BY id DESC`
+	query := `SELECT e.id, e.date, e.title, e.category_id, IFNULL(ec.name, ''), e.total, e.description, e.paid, e.created_at
+                FROM expenses e
+                LEFT JOIN expense_categories ec ON e.category_id = ec.id
+                ORDER BY e.id DESC`
 	rows, err := r.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
@@ -34,7 +38,7 @@ func (r *ExpenseRepository) GetAll(ctx context.Context) ([]models.Expense, error
 	var result []models.Expense
 	for rows.Next() {
 		var e models.Expense
-		err := rows.Scan(&e.ID, &e.Date, &e.Title, &e.Category, &e.Total, &e.Description, &e.CreatedAt)
+		err := rows.Scan(&e.ID, &e.Date, &e.Title, &e.CategoryID, &e.Category, &e.Total, &e.Description, &e.Paid, &e.CreatedAt)
 		if err != nil {
 			return nil, err
 		}
@@ -44,9 +48,12 @@ func (r *ExpenseRepository) GetAll(ctx context.Context) ([]models.Expense, error
 }
 
 func (r *ExpenseRepository) GetByID(ctx context.Context, id int) (*models.Expense, error) {
-	query := `SELECT id, date, title, category, total, description, created_at FROM expenses WHERE id = ?`
+	query := `SELECT e.id, e.date, e.title, e.category_id, IFNULL(ec.name, ''), e.total, e.description, e.paid, e.created_at
+                FROM expenses e
+                LEFT JOIN expense_categories ec ON e.category_id = ec.id
+                WHERE e.id = ?`
 	var e models.Expense
-	err := r.db.QueryRowContext(ctx, query, id).Scan(&e.ID, &e.Date, &e.Title, &e.Category, &e.Total, &e.Description, &e.CreatedAt)
+	err := r.db.QueryRowContext(ctx, query, id).Scan(&e.ID, &e.Date, &e.Title, &e.CategoryID, &e.Category, &e.Total, &e.Description, &e.Paid, &e.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +61,8 @@ func (r *ExpenseRepository) GetByID(ctx context.Context, id int) (*models.Expens
 }
 
 func (r *ExpenseRepository) Update(ctx context.Context, e *models.Expense) error {
-	query := `UPDATE expenses SET date=?, title=?, category=?, total=?, description=? WHERE id=?`
-	_, err := r.db.ExecContext(ctx, query, e.Date, e.Title, e.Category, e.Total, e.Description, e.ID)
+	query := `UPDATE expenses SET date=?, title=?, category_id=NULLIF(?,0), total=?, description=?, paid=? WHERE id=?`
+	_, err := r.db.ExecContext(ctx, query, e.Date, e.Title, e.CategoryID, e.Total, e.Description, e.Paid, e.ID)
 	return err
 }
 

--- a/internal/repositories/repair_repository.go
+++ b/internal/repositories/repair_repository.go
@@ -15,8 +15,8 @@ func NewRepairRepository(db *sql.DB) *RepairRepository {
 }
 
 func (r *RepairRepository) Create(ctx context.Context, rep *models.Repair) (int, error) {
-	query := `INSERT INTO repairs (date, color, vin, description, price, created_at, updated_at) VALUES (?, ?, ?, ?, ?, NOW(), NOW())`
-	res, err := r.db.ExecContext(ctx, query, rep.Date, rep.Color, rep.VIN, rep.Description, rep.Price)
+	query := `INSERT INTO repairs (date, vin, description, price, created_at, updated_at) VALUES (?, ?, ?, ?, NOW(), NOW())`
+	res, err := r.db.ExecContext(ctx, query, rep.Date, rep.VIN, rep.Description, rep.Price)
 	if err != nil {
 		return 0, err
 	}
@@ -25,7 +25,7 @@ func (r *RepairRepository) Create(ctx context.Context, rep *models.Repair) (int,
 }
 
 func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) {
-	query := `SELECT id, date, color, vin, description, price, created_at, updated_at FROM repairs ORDER BY id DESC`
+	query := `SELECT id, date, vin, description, price, created_at, updated_at FROM repairs ORDER BY id DESC`
 	rows, err := r.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) 
 	var result []models.Repair
 	for rows.Next() {
 		var rep models.Repair
-		err := rows.Scan(&rep.ID, &rep.Date, &rep.Color, &rep.VIN, &rep.Description, &rep.Price, &rep.CreatedAt, &rep.UpdatedAt)
+		err := rows.Scan(&rep.ID, &rep.Date, &rep.VIN, &rep.Description, &rep.Price, &rep.CreatedAt, &rep.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
@@ -44,9 +44,9 @@ func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) 
 }
 
 func (r *RepairRepository) GetByID(ctx context.Context, id int) (*models.Repair, error) {
-	query := `SELECT id, date, color, vin, description, price, created_at, updated_at FROM repairs WHERE id = ?`
+	query := `SELECT id, date, vin, description, price, created_at, updated_at FROM repairs WHERE id = ?`
 	var rep models.Repair
-	err := r.db.QueryRowContext(ctx, query, id).Scan(&rep.ID, &rep.Date, &rep.Color, &rep.VIN, &rep.Description, &rep.Price, &rep.CreatedAt, &rep.UpdatedAt)
+	err := r.db.QueryRowContext(ctx, query, id).Scan(&rep.ID, &rep.Date, &rep.VIN, &rep.Description, &rep.Price, &rep.CreatedAt, &rep.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +54,8 @@ func (r *RepairRepository) GetByID(ctx context.Context, id int) (*models.Repair,
 }
 
 func (r *RepairRepository) Update(ctx context.Context, rep *models.Repair) error {
-	query := `UPDATE repairs SET date = ?, color = ?, vin = ?, description = ?, price = ?, updated_at = NOW() WHERE id = ?`
-	_, err := r.db.ExecContext(ctx, query, rep.Date, rep.Color, rep.VIN, rep.Description, rep.Price, rep.ID)
+	query := `UPDATE repairs SET date = ?, vin = ?, description = ?, price = ?, updated_at = NOW() WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, rep.Date, rep.VIN, rep.Description, rep.Price, rep.ID)
 	return err
 }
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -10,6 +10,7 @@ func SetupRoutes(
 	authHandler *handlers.AuthHandler,
 	clientHandler *handlers.ClientHandler,
 	userHandler *handlers.UserHandler,
+	expCatHandler *handlers.ExpenseCategoryHandler,
 	expenseHandler *handlers.ExpenseHandler,
 	tableHandler *handlers.TableHandler,
 	tableCategoryHandler *handlers.TableCategoryHandler,
@@ -157,6 +158,15 @@ func SetupRoutes(
 		bookings.DELETE("/:id", bookingHandler.DeleteBooking)
 		// Можно добавить эндпоинт для получения позиций бронирования:
 		// bookings.GET("/:id/items", bookingHandler.GetBookingItemsByBookingID)
+	}
+
+	// --- Категории расходов
+	expenseCats := api.Group("/expense-categories")
+	{
+		expenseCats.POST("", expCatHandler.Create)
+		expenseCats.GET("", expCatHandler.GetAll)
+		expenseCats.PUT("/:id", expCatHandler.Update)
+		expenseCats.DELETE("/:id", expCatHandler.Delete)
 	}
 
 	// --- Расходы

--- a/internal/services/expense_category_service.go
+++ b/internal/services/expense_category_service.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"context"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/repositories"
+)
+
+type ExpenseCategoryService struct {
+	repo *repositories.ExpenseCategoryRepository
+}
+
+func NewExpenseCategoryService(r *repositories.ExpenseCategoryRepository) *ExpenseCategoryService {
+	return &ExpenseCategoryService{repo: r}
+}
+
+func (s *ExpenseCategoryService) Create(ctx context.Context, c *models.ExpenseCategory) (int, error) {
+	return s.repo.Create(ctx, c)
+}
+
+func (s *ExpenseCategoryService) GetAll(ctx context.Context) ([]models.ExpenseCategory, error) {
+	return s.repo.GetAll(ctx)
+}
+
+func (s *ExpenseCategoryService) Update(ctx context.Context, c *models.ExpenseCategory) error {
+	return s.repo.Update(ctx, c)
+}
+
+func (s *ExpenseCategoryService) Delete(ctx context.Context, id int) error {
+	return s.repo.Delete(ctx, id)
+}


### PR DESCRIPTION
## Summary
- generate an expense whenever a price item is replenished
- generate an expense whenever a repair is created
- allow missing expense category by inserting NULL if ID is zero
- wire expense service into price and repair handlers
- include paid expenses grouped by category in sales reports

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685416d8b120832490046cfdfe7f72a2