### PR TITLE
Update Replenish to persist buy price

### DIFF
--- a/internal/repositories/price_item_repository.go
+++ b/internal/repositories/price_item_repository.go
@@ -72,6 +72,12 @@ func (r *PriceItemRepository) IncreaseStock(ctx context.Context, id int, amount 
 	return err
 }
 
+// UpdateBuyPrice sets a new buy price for the item.
+func (r *PriceItemRepository) UpdateBuyPrice(ctx context.Context, id int, price float64) error {
+	_, err := r.db.ExecContext(ctx, `UPDATE price_items SET buy_price=? WHERE id=?`, price, id)
+	return err
+}
+
 // При продаже/списании уменьшаем остаток
 func (r *PriceItemRepository) DecreaseStock(ctx context.Context, id int, amount int) error {
 	query := `UPDATE price_items SET quantity = quantity - ? WHERE id = ? AND quantity >= ?`

--- a/internal/services/price_item_service.go
+++ b/internal/services/price_item_service.go
@@ -90,6 +90,11 @@ func (s *PriceItemService) Replenish(ctx context.Context, hist *models.Pricelist
 	if _, err := s.plHistoryRepo.Create(ctx, hist); err != nil {
 		return err
 	}
+
+	if err := s.repo.UpdateBuyPrice(ctx, hist.PriceItemID, hist.BuyPrice); err != nil {
+		return err
+	}
+
 	return s.repo.IncreaseStock(ctx, hist.PriceItemID, hist.Quantity)
 }
 


### PR DESCRIPTION
## Summary
- update price item service to persist new buy price when replenishing stock
- add repository helper to update buy price

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6856b76321fc832491ef383469a80294