### PR TITLE
Auto map expense category on replenishment

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -106,8 +106,8 @@ func Run() {
 	expenseService := services.NewExpenseService(expenseRepo)
 	expenseHandler := handlers.NewExpenseHandler(expenseService)
 
-	// Прайс-лист handlers depend on expense service
-	priceHandler := handlers.NewPriceItemHandler(priceService, expenseService)
+	// Прайс-лист handlers depend on expense and category services
+	priceHandler := handlers.NewPriceItemHandler(priceService, expenseService, expCatService, categoryService)
 	plHistoryHandler := handlers.NewPricelistHistoryHandler(priceService)
 
 	// Ремонты

--- a/internal/repositories/expense_category_repository.go
+++ b/internal/repositories/expense_category_repository.go
@@ -49,3 +49,16 @@ func (r *ExpenseCategoryRepository) Delete(ctx context.Context, id int) error {
 	_, err := r.db.ExecContext(ctx, `DELETE FROM expense_categories WHERE id=?`, id)
 	return err
 }
+
+func (r *ExpenseCategoryRepository) GetByName(ctx context.Context, name string) (*models.ExpenseCategory, error) {
+	query := `SELECT id, name FROM expense_categories WHERE name = ?`
+	var c models.ExpenseCategory
+	err := r.db.QueryRowContext(ctx, query, name).Scan(&c.ID, &c.Name)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}

--- a/internal/services/expense_category_service.go
+++ b/internal/services/expense_category_service.go
@@ -29,3 +29,7 @@ func (s *ExpenseCategoryService) Update(ctx context.Context, c *models.ExpenseCa
 func (s *ExpenseCategoryService) Delete(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
+
+func (s *ExpenseCategoryService) GetByName(ctx context.Context, name string) (*models.ExpenseCategory, error) {
+	return s.repo.GetByName(ctx, name)
+}


### PR DESCRIPTION
## Summary
- add GetByName method for expense category repo and service
- inject expense & category services into price item handler
- auto-create expense categories during stock replenish

## Testing
- `go vet ./...` *(fails: forbidden due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd2dfc148324a6cb2b3687206c5c