### PR TITLE
Update client stats on booking

### DIFF
--- a/internal/repositories/client_repository.go
+++ b/internal/repositories/client_repository.go
@@ -96,3 +96,15 @@ func (r *ClientRepository) GetByPhone(ctx context.Context, phone string) (*model
 	}
 	return &c, nil
 }
+
+func (r *ClientRepository) AddVisits(ctx context.Context, clientID int, visits int) error {
+	query := `UPDATE clients SET visits = visits + ? WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, visits, clientID)
+	return err
+}
+
+func (r *ClientRepository) AddIncome(ctx context.Context, clientID int, income int) error {
+	query := `UPDATE clients SET income = income + ? WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, income, clientID)
+	return err
+}


### PR DESCRIPTION
## Summary
- add methods to increment/decrement client visits and income
- update booking service to modify client stats on create/delete

## Testing
- `go vet ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856ea6bacdc832491f15bdcfbd72341