### PR TITLE
Handle hours category without stock changes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -94,6 +94,7 @@ func Run() {
 		settingsRepo,
 		priceRepo,
 		priceSetRepo,
+		categoryRepo,
 	)
 	bookingHandler := handlers.NewBookingHandler(bookingService)
 


### PR DESCRIPTION
## Summary
- update booking service to inject category repo and detect 'Часы' category
- skip stock decreases/increases for items in this category
- ignore 'Часы' items when calculating set availability
- pass category repo when creating booking service

## Testing
- `go vet ./...` *(fails: modules blocked)*
- `go test ./...` *(fails: modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856fb93adbc8324945d786327e8a290