### PR TITLE
Add dynamic quantity for price sets

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,7 +80,7 @@ func Run() {
 
 	// Сеты товаров
 	priceSetRepo := repositories.NewPriceSetRepository(db)
-	priceSetService := services.NewPriceSetService(priceSetRepo)
+	priceSetService := services.NewPriceSetService(priceSetRepo, priceRepo, categoryRepo)
 	priceSetHandler := handlers.NewPriceSetHandler(priceSetService)
 
 	// Бронирования

--- a/internal/models/price_set.go
+++ b/internal/models/price_set.go
@@ -5,6 +5,7 @@ type PriceSet struct {
 	Name            string    `json:"name"`
 	CategoryID      int       `json:"category_id"`
 	SubcategoryID   int       `json:"subcategory_id"`
+	Quantity        int       `json:"quantity"`
 	Price           int       `json:"price"`
 	SubcategoryName string    `json:"subcategory_name,omitempty"`
 	Items           []SetItem `json:"items"`

--- a/internal/services/price_set_service.go
+++ b/internal/services/price_set_service.go
@@ -2,34 +2,107 @@ package services
 
 import (
 	"context"
+	"math"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
 )
 
 type PriceSetService struct {
-	repo *repositories.PriceSetRepository
+	repo         *repositories.PriceSetRepository
+	itemRepo     *repositories.PriceItemRepository
+	categoryRepo *repositories.CategoryRepository
 }
 
-func NewPriceSetService(r *repositories.PriceSetRepository) *PriceSetService {
-	return &PriceSetService{repo: r}
+const hoursCategoryName = "\u0427\u0430\u0441\u044b"
+
+func (s *PriceSetService) isHoursCategory(ctx context.Context, categoryID int) (bool, error) {
+	cat, err := s.categoryRepo.GetByID(ctx, categoryID)
+	if err != nil {
+		return false, err
+	}
+	return cat.Name == hoursCategoryName, nil
+}
+
+func NewPriceSetService(r *repositories.PriceSetRepository, ir *repositories.PriceItemRepository, cr *repositories.CategoryRepository) *PriceSetService {
+	return &PriceSetService{repo: r, itemRepo: ir, categoryRepo: cr}
 }
 
 func (s *PriceSetService) CreatePriceSet(ctx context.Context, ps *models.PriceSet) (int, error) {
-	return s.repo.Create(ctx, ps)
+	id, err := s.repo.Create(ctx, ps)
+	if err != nil {
+		return 0, err
+	}
+	ps.ID = id
+	qty, err := s.calculateQuantity(ctx, ps)
+	if err == nil {
+		ps.Quantity = qty
+	}
+	return id, nil
 }
 
 func (s *PriceSetService) GetAllPriceSets(ctx context.Context) ([]models.PriceSet, error) {
-	return s.repo.GetAll(ctx)
+	sets, err := s.repo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range sets {
+		qty, err := s.calculateQuantity(ctx, &sets[i])
+		if err != nil {
+			return nil, err
+		}
+		sets[i].Quantity = qty
+	}
+	return sets, nil
 }
 
 func (s *PriceSetService) GetPriceSetByID(ctx context.Context, id int) (*models.PriceSet, error) {
-	return s.repo.GetByID(ctx, id)
+	set, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	qty, err := s.calculateQuantity(ctx, set)
+	if err == nil {
+		set.Quantity = qty
+	}
+	return set, nil
 }
 
 func (s *PriceSetService) UpdatePriceSet(ctx context.Context, ps *models.PriceSet) error {
-	return s.repo.Update(ctx, ps)
+	if err := s.repo.Update(ctx, ps); err != nil {
+		return err
+	}
+	qty, err := s.calculateQuantity(ctx, ps)
+	if err == nil {
+		ps.Quantity = qty
+	}
+	return nil
 }
 
 func (s *PriceSetService) DeletePriceSet(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
+}
+
+func (s *PriceSetService) calculateQuantity(ctx context.Context, ps *models.PriceSet) (int, error) {
+	qty := math.MaxInt32
+	for _, it := range ps.Items {
+		item, err := s.itemRepo.GetByID(ctx, it.ItemID)
+		if err != nil {
+			return 0, err
+		}
+		hours, err := s.isHoursCategory(ctx, item.CategoryID)
+		if err != nil {
+			return 0, err
+		}
+		if hours {
+			continue
+		}
+		avail := item.Quantity / it.Quantity
+		if avail < qty {
+			qty = avail
+		}
+	}
+	if qty == math.MaxInt32 {
+		qty = 0
+	}
+	return qty, nil
 }


### PR DESCRIPTION
## Summary
- extend `PriceSet` model with `quantity`
- compute available quantity for each set in `PriceSetService`
- provide repositories to the service and use them in the app setup

## Testing
- `go build ./...` *(fails: access denied)*
- `go vet ./...` *(fails: access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68592ec7298483248c5878ff993e58a9