### PR TITLE
Add channels table and settings endpoints

### DIFF
--- a/db/migrations/008_channels.up.sql
+++ b/db/migrations/008_channels.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS channels (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+ALTER TABLE clients ADD COLUMN channel_id INT;
+ALTER TABLE clients DROP COLUMN channel;
+ALTER TABLE clients ADD CONSTRAINT fk_clients_channel FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE SET NULL;

--- a/db/migrations/009_pricelist_history_float.up.sql
+++ b/db/migrations/009_pricelist_history_float.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pricelist_history MODIFY COLUMN quantity DOUBLE NOT NULL;

--- a/db/migrations/010_settings_update.up.sql
+++ b/db/migrations/010_settings_update.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE settings
+    ADD COLUMN tables_count INT DEFAULT 0,
+    ADD COLUMN notification_time INT DEFAULT 0;

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -32,6 +32,11 @@ func Run() {
 	clientService := services.NewClientService(clientRepo)
 	clientHandler := handlers.NewClientHandler(clientService)
 
+	// Каналы привлечения
+	channelRepo := repositories.NewChannelRepository(db)
+	channelService := services.NewChannelService(channelRepo)
+	channelHandler := handlers.NewChannelHandler(channelService)
+
 	// Сотрудники (Users)
 	userRepo := repositories.NewUserRepository(db)
 	tokenRepo := repositories.NewTokenRepository(db)
@@ -109,7 +114,7 @@ func Run() {
 
 	// Прайс-лист handlers depend on expense and category services
 	priceHandler := handlers.NewPriceItemHandler(priceService, expenseService, expCatService, categoryService)
-	plHistoryHandler := handlers.NewPricelistHistoryHandler(priceService)
+	plHistoryHandler := handlers.NewPricelistHistoryHandler(priceService, expenseService)
 
 	// Ремонты
 	repairRepo := repositories.NewRepairRepository(db)
@@ -140,6 +145,7 @@ func Run() {
 		router,
 		authHandler,
 		clientHandler,
+		channelHandler,
 		userHandler,
 		expCatHandler,
 		expenseHandler,

--- a/internal/handlers/channel_handler.go
+++ b/internal/handlers/channel_handler.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/services"
+)
+
+type ChannelHandler struct {
+	service *services.ChannelService
+}
+
+func NewChannelHandler(s *services.ChannelService) *ChannelHandler {
+	return &ChannelHandler{service: s}
+}
+
+func (h *ChannelHandler) Create(c *gin.Context) {
+	var ch models.Channel
+	if err := c.ShouldBindJSON(&ch); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.service.Create(c.Request.Context(), &ch)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ch.ID = id
+	c.JSON(http.StatusCreated, ch)
+}
+
+func (h *ChannelHandler) GetAll(c *gin.Context) {
+	list, err := h.service.GetAll(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+func (h *ChannelHandler) Update(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var ch models.Channel
+	if err := c.ShouldBindJSON(&ch); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ch.ID = id
+	if err := h.service.Update(c.Request.Context(), &ch); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, ch)
+}
+
+func (h *ChannelHandler) Delete(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *ChannelHandler) GetByID(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	ch, err := h.service.GetByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, ch)
+}

--- a/internal/handlers/price_item_handler.go
+++ b/internal/handlers/price_item_handler.go
@@ -253,7 +253,7 @@ func (h *PriceItemHandler) Replenish(c *gin.Context) {
 		Total:       hist.Total,
 		Paid:        false,
 		CategoryID:  expCatID,
-		Description: "Пополнение товара " + item.Name + " в количестве " + strconv.Itoa(in.Quantity) + " шт.",
+		Description: "Пополнение товара " + item.Name + " в количестве " + strconv.FormatFloat(in.Quantity, 'f', -1, 64) + " шт.",
 	}
 	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
 

--- a/internal/handlers/pricelist_history_handler.go
+++ b/internal/handlers/pricelist_history_handler.go
@@ -9,11 +9,12 @@ import (
 )
 
 type PricelistHistoryHandler struct {
-	service *services.PriceItemService
+	service  *services.PriceItemService
+	expenses *services.ExpenseService
 }
 
-func NewPricelistHistoryHandler(s *services.PriceItemService) *PricelistHistoryHandler {
-	return &PricelistHistoryHandler{service: s}
+func NewPricelistHistoryHandler(s *services.PriceItemService, e *services.ExpenseService) *PricelistHistoryHandler {
+	return &PricelistHistoryHandler{service: s, expenses: e}
 }
 
 // POST /api/pricelist-history
@@ -71,3 +72,26 @@ func (h *PricelistHistoryHandler) GetByCategory(c *gin.Context) {
 	c.JSON(http.StatusOK, history)
 }
 
+func (h *PricelistHistoryHandler) Delete(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	hist, err := h.service.GetPricelistHistoryByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.service.DeletePricelistHistory(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	item, _ := h.service.GetPriceItemByID(c.Request.Context(), hist.PriceItemID)
+	if item != nil {
+		title := "Пополнение " + item.Name
+		desc := "Пополнение товара " + item.Name + " в количестве " + strconv.FormatFloat(hist.Quantity, 'f', -1, 64) + " шт."
+		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, desc, hist.Total)
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/settings_handler.go
+++ b/internal/handlers/settings_handler.go
@@ -71,3 +71,21 @@ func (h *SettingsHandler) DeleteSettings(c *gin.Context) {
 	}
 	c.Status(http.StatusNoContent)
 }
+
+func (h *SettingsHandler) GetTablesCount(c *gin.Context) {
+	cnt, err := h.service.GetTablesCount(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"tables_count": cnt})
+}
+
+func (h *SettingsHandler) GetNotificationTime(c *gin.Context) {
+	n, err := h.service.GetNotificationTime(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"notification_time": n})
+}

--- a/internal/models/channel.go
+++ b/internal/models/channel.go
@@ -1,0 +1,6 @@
+package models
+
+type Channel struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}

--- a/internal/models/client.go
+++ b/internal/models/client.go
@@ -7,6 +7,7 @@ type Client struct {
 	Name        string     `json:"name"`
 	Phone       string     `json:"phone"`
 	DateOfBirth *time.Time `json:"date_of_birth,omitempty"`
+	ChannelID   int        `json:"channel_id"`
 	Channel     string     `json:"channel,omitempty"`
 	Bonus       int        `json:"bonus"`
 	Visits      int        `json:"visits"`

--- a/internal/models/pricelist_history.go
+++ b/internal/models/pricelist_history.go
@@ -6,7 +6,7 @@ type PricelistHistory struct {
 	ID          int       `json:"id"`
 	ItemName    string    `json:"item_name"`
 	PriceItemID int       `json:"price_item_id"`
-	Quantity    int       `json:"quantity"`
+	Quantity    float64   `json:"quantity"`
 	BuyPrice    float64   `json:"buy_price"`
 	Total       float64   `json:"total"`
 	UserID      int       `json:"user_id"`

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -1,11 +1,13 @@
 package models
 
 type Settings struct {
-	ID           int           `json:"id"`
-	PaymentType  int           `json:"payment_type"`
-	BlockTime    int           `json:"block_time"`
-	BonusPercent int           `json:"bonus_percent"`
-	WorkTimeFrom string        `json:"work_time_from"`
-	WorkTimeTo   string        `json:"work_time_to"`
-	PaymentTypes []PaymentType `json:"payment_types"` // список всех типов
+	ID               int           `json:"id"`
+	PaymentType      int           `json:"payment_type"`
+	BlockTime        int           `json:"block_time"`
+	BonusPercent     int           `json:"bonus_percent"`
+	WorkTimeFrom     string        `json:"work_time_from"`
+	WorkTimeTo       string        `json:"work_time_to"`
+	TablesCount      int           `json:"tables_count"`
+	NotificationTime int           `json:"notification_time"`
+	PaymentTypes     []PaymentType `json:"payment_types"` // список всех типов
 }

--- a/internal/repositories/channel_repository.go
+++ b/internal/repositories/channel_repository.go
@@ -1,0 +1,61 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"psclub-crm/internal/models"
+)
+
+type ChannelRepository struct {
+	db *sql.DB
+}
+
+func NewChannelRepository(db *sql.DB) *ChannelRepository {
+	return &ChannelRepository{db: db}
+}
+
+func (r *ChannelRepository) Create(ctx context.Context, ch *models.Channel) (int, error) {
+	res, err := r.db.ExecContext(ctx, `INSERT INTO channels (name) VALUES (?)`, ch.Name)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *ChannelRepository) GetAll(ctx context.Context) ([]models.Channel, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, name FROM channels ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.Channel
+	for rows.Next() {
+		var ch models.Channel
+		if err := rows.Scan(&ch.ID, &ch.Name); err != nil {
+			return nil, err
+		}
+		result = append(result, ch)
+	}
+	return result, nil
+}
+
+func (r *ChannelRepository) Update(ctx context.Context, ch *models.Channel) error {
+	_, err := r.db.ExecContext(ctx, `UPDATE channels SET name=? WHERE id=?`, ch.Name, ch.ID)
+	return err
+}
+
+func (r *ChannelRepository) Delete(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM channels WHERE id=?`, id)
+	return err
+}
+
+func (r *ChannelRepository) GetByID(ctx context.Context, id int) (*models.Channel, error) {
+	var ch models.Channel
+	err := r.db.QueryRowContext(ctx, `SELECT id, name FROM channels WHERE id=?`, id).Scan(&ch.ID, &ch.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &ch, nil
+}

--- a/internal/repositories/expense_repository.go
+++ b/internal/repositories/expense_repository.go
@@ -70,3 +70,8 @@ func (r *ExpenseRepository) Delete(ctx context.Context, id int) error {
 	_, err := r.db.ExecContext(ctx, `DELETE FROM expenses WHERE id=?`, id)
 	return err
 }
+
+func (r *ExpenseRepository) DeleteByDetails(ctx context.Context, title, description string, total float64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM expenses WHERE title=? AND description=? AND total=?`, title, description, total)
+	return err
+}

--- a/internal/repositories/pricelist_history_repository.go
+++ b/internal/repositories/pricelist_history_repository.go
@@ -61,6 +61,24 @@ func (r *PricelistHistoryRepository) GetAll(ctx context.Context) ([]models.Price
 	}
 	return result, nil
 }
+
+func (r *PricelistHistoryRepository) GetByID(ctx context.Context, id int) (*models.PricelistHistory, error) {
+	query := `SELECT ph.id, pi.name, ph.price_item_id, ph.quantity, ph.buy_price, ph.total, ph.user_id, ph.created_at
+                FROM pricelist_history ph
+                JOIN price_items pi ON ph.price_item_id = pi.id
+                WHERE ph.id = ?`
+	var h models.PricelistHistory
+	err := r.db.QueryRowContext(ctx, query, id).Scan(&h.ID, &h.ItemName, &h.PriceItemID, &h.Quantity, &h.BuyPrice, &h.Total, &h.UserID, &h.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+func (r *PricelistHistoryRepository) Delete(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM pricelist_history WHERE id=?`, id)
+	return err
+}
 func (r *PricelistHistoryRepository) GetByCategory(ctx context.Context, categoryID int) ([]models.PricelistHistory, error) {
 	query := `SELECT ph.id, ph.price_item_id, ph.quantity, ph.buy_price, ph.total, ph.user_id, ph.created_at, u.name AS user_name
                 FROM pricelist_history ph

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -9,6 +9,7 @@ func SetupRoutes(
 	r *gin.Engine,
 	authHandler *handlers.AuthHandler,
 	clientHandler *handlers.ClientHandler,
+	channelHandler *handlers.ChannelHandler,
 	userHandler *handlers.UserHandler,
 	expCatHandler *handlers.ExpenseCategoryHandler,
 	expenseHandler *handlers.ExpenseHandler,
@@ -44,6 +45,16 @@ func SetupRoutes(
 		clients.GET("/:id", clientHandler.GetClientByID)
 		clients.PUT("/:id", clientHandler.UpdateClient)
 		clients.DELETE("/:id", clientHandler.DeleteClient)
+	}
+
+	// --- Каналы привлечения
+	channels := api.Group("/channels")
+	{
+		channels.POST("", channelHandler.Create)
+		channels.GET("", channelHandler.GetAll)
+		channels.GET("/:id", channelHandler.GetByID)
+		channels.PUT("/:id", channelHandler.Update)
+		channels.DELETE("/:id", channelHandler.Delete)
 	}
 
 	// --- Сотрудники (Users)
@@ -134,8 +145,8 @@ func SetupRoutes(
 		plHistory.POST("", pricelistHistoryHandler.Create)
 		plHistory.GET("", pricelistHistoryHandler.GetAll)
 		plHistory.GET("/item/:id", pricelistHistoryHandler.GetByItem)
-
 		plHistory.GET("/category/:id", pricelistHistoryHandler.GetByCategory)
+		plHistory.DELETE("/:id", pricelistHistoryHandler.Delete)
 
 	}
 
@@ -201,6 +212,8 @@ func SetupRoutes(
 	{
 		settings.POST("", settingsHandler.CreateSettings)
 		settings.GET("", settingsHandler.GetSettings)
+		settings.GET("/tables-count", settingsHandler.GetTablesCount)
+		settings.GET("/notification-time", settingsHandler.GetNotificationTime)
 		settings.PUT("/:id", settingsHandler.UpdateSettings)
 		settings.DELETE("/:id", settingsHandler.DeleteSettings)
 	}

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"context"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/repositories"
+)
+
+type ChannelService struct {
+	repo *repositories.ChannelRepository
+}
+
+func NewChannelService(r *repositories.ChannelRepository) *ChannelService {
+	return &ChannelService{repo: r}
+}
+
+func (s *ChannelService) Create(ctx context.Context, ch *models.Channel) (int, error) {
+	return s.repo.Create(ctx, ch)
+}
+
+func (s *ChannelService) GetAll(ctx context.Context) ([]models.Channel, error) {
+	return s.repo.GetAll(ctx)
+}
+
+func (s *ChannelService) Update(ctx context.Context, ch *models.Channel) error {
+	return s.repo.Update(ctx, ch)
+}
+
+func (s *ChannelService) Delete(ctx context.Context, id int) error {
+	return s.repo.Delete(ctx, id)
+}
+
+func (s *ChannelService) GetByID(ctx context.Context, id int) (*models.Channel, error) {
+	return s.repo.GetByID(ctx, id)
+}

--- a/internal/services/expense_service.go
+++ b/internal/services/expense_service.go
@@ -33,3 +33,7 @@ func (s *ExpenseService) UpdateExpense(ctx context.Context, e *models.Expense) e
 func (s *ExpenseService) DeleteExpense(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
+
+func (s *ExpenseService) DeleteByDetails(ctx context.Context, title, description string, total float64) error {
+	return s.repo.DeleteByDetails(ctx, title, description, total)
+}

--- a/internal/services/price_item_service.go
+++ b/internal/services/price_item_service.go
@@ -111,3 +111,11 @@ func (s *PriceItemService) GetPricelistHistoryByCategory(ctx context.Context, ca
 func (s *PriceItemService) GetAllPricelistHistory(ctx context.Context) ([]models.PricelistHistory, error) {
 	return s.plHistoryRepo.GetAll(ctx)
 }
+
+func (s *PriceItemService) GetPricelistHistoryByID(ctx context.Context, id int) (*models.PricelistHistory, error) {
+	return s.plHistoryRepo.GetByID(ctx, id)
+}
+
+func (s *PriceItemService) DeletePricelistHistory(ctx context.Context, id int) error {
+	return s.plHistoryRepo.Delete(ctx, id)
+}

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -29,3 +29,11 @@ func (s *SettingsService) CreateSettings(ctx context.Context, set *models.Settin
 func (s *SettingsService) DeleteSettings(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
+
+func (s *SettingsService) GetTablesCount(ctx context.Context) (int, error) {
+	return s.repo.GetTablesCount(ctx)
+}
+
+func (s *SettingsService) GetNotificationTime(ctx context.Context) (int, error) {
+	return s.repo.GetNotificationTime(ctx)
+}


### PR DESCRIPTION
## Summary
- add `channels` table and CRUD endpoints
- replace client `channel` with `channel_id`
- switch `PricelistHistory` quantity field to float
- support deleting pricelist history along with related expense
- extend `settings` with `tables_count` and `notification_time` and provide endpoints to get them

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a6784ee988324bec97fed00b4ead1