### PR TITLE
Add channels to settings response

### DIFF
--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -10,4 +10,5 @@ type Settings struct {
 	TablesCount      int           `json:"tables_count"`
 	NotificationTime int           `json:"notification_time"`
 	PaymentTypes     []PaymentType `json:"payment_types"` // список всех типов
+	Channels         []Channel     `json:"channels"`      // список всех каналов
 }

--- a/internal/repositories/settings_repository.go
+++ b/internal/repositories/settings_repository.go
@@ -48,6 +48,24 @@ func (r *SettingsRepository) Get(ctx context.Context) (*models.Settings, error) 
 	}
 	s.PaymentTypes = types
 
+	// Получить список всех channels
+	chQuery := `SELECT id, name FROM channels ORDER BY id`
+	chRows, err := r.db.QueryContext(ctx, chQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer chRows.Close()
+
+	var channels []models.Channel
+	for chRows.Next() {
+		var ch models.Channel
+		if err := chRows.Scan(&ch.ID, &ch.Name); err != nil {
+			return nil, err
+		}
+		channels = append(channels, ch)
+	}
+	s.Channels = channels
+
 	return &s, nil
 }
 


### PR DESCRIPTION
## Summary
- extend settings model with `Channels` field
- fetch channels in settings repository so GetSettings returns available channels

## Testing
- `go vet ./...` *(fails: Forbidden due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685b7c3247e08324bdfcb3b6bcd19511