### PR TITLE
Add set support for bookings

### DIFF
--- a/internal/repositories/price_set_repository.go
+++ b/internal/repositories/price_set_repository.go
@@ -19,7 +19,13 @@ func (r *PriceSetRepository) Create(ctx context.Context, s *models.PriceSet) (in
 	if err != nil {
 		return 0, err
 	}
-	res, err := tx.ExecContext(ctx, `INSERT INTO price_sets (name, category_id, subcategory_id, price) VALUES (?, ?, ?, ?)`, s.Name, s.CategoryID, s.SubcategoryID, s.Price)
+	query := `INSERT INTO price_sets (name, category_id, subcategory_id, price) VALUES (?, ?, ?, ?)`
+	args := []any{s.Name, s.CategoryID, s.SubcategoryID, s.Price}
+	if s.ID > 0 {
+		query = `INSERT INTO price_sets (id, name, category_id, subcategory_id, price) VALUES (?, ?, ?, ?, ?)`
+		args = []any{s.ID, s.Name, s.CategoryID, s.SubcategoryID, s.Price}
+	}
+	res, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		tx.Rollback()
 		return 0, err
@@ -28,6 +34,9 @@ func (r *PriceSetRepository) Create(ctx context.Context, s *models.PriceSet) (in
 	if err != nil {
 		tx.Rollback()
 		return 0, err
+	}
+	if s.ID > 0 {
+		setID = int64(s.ID)
 	}
 	if len(s.Items) > 0 {
 		for _, it := range s.Items {


### PR DESCRIPTION
## Summary
- link `price_sets` with `price_items` so sets behave like usual items
- create/update/delete corresponding `price_items` when managing sets
- allow explicit ID when inserting into `price_sets`

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bd886127c8324bf3ecc8339769e95