### PR TITLE
Fix expense handling for repairs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -119,7 +119,7 @@ func Run() {
 	// Ремонты
 	repairRepo := repositories.NewRepairRepository(db)
 	repairService := services.NewRepairService(repairRepo)
-	repairHandler := handlers.NewRepairHandler(repairService, expenseService)
+	repairHandler := handlers.NewRepairHandler(repairService, expenseService, expCatService)
 
 	// Касса
 	cashboxRepo := repositories.NewCashboxRepository(db)

--- a/internal/handlers/repair_handler.go
+++ b/internal/handlers/repair_handler.go
@@ -12,10 +12,11 @@ import (
 type RepairHandler struct {
 	service  *services.RepairService
 	expenses *services.ExpenseService
+	expCats  *services.ExpenseCategoryService
 }
 
-func NewRepairHandler(s *services.RepairService, expenseService *services.ExpenseService) *RepairHandler {
-	return &RepairHandler{service: s, expenses: expenseService}
+func NewRepairHandler(s *services.RepairService, expenseService *services.ExpenseService, catService *services.ExpenseCategoryService) *RepairHandler {
+	return &RepairHandler{service: s, expenses: expenseService, expCats: catService}
 }
 
 // POST /api/repairs
@@ -32,12 +33,22 @@ func (h *RepairHandler) CreateRepair(c *gin.Context) {
 	}
 	rep.ID = id
 
+	// ensure expense category "Ремонт" exists
+	var catID int
+	if cat, _ := h.expCats.GetByName(c.Request.Context(), "Ремонт"); cat != nil {
+		catID = cat.ID
+	} else {
+		newCat := models.ExpenseCategory{Name: "Ремонт"}
+		catID, _ = h.expCats.Create(c.Request.Context(), &newCat)
+	}
+
 	exp := models.Expense{
 		Date:        time.Now(),
 		Title:       "Починка, номер VIN: " + rep.VIN,
 		Total:       rep.Price,
 		Description: rep.Description,
 		Paid:        false,
+		CategoryID:  catID,
 	}
 	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
 
@@ -81,12 +92,37 @@ func (h *RepairHandler) UpdateRepair(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	oldRep, _ := h.service.GetRepairByID(c.Request.Context(), id)
 	rep.ID = id
 	err = h.service.UpdateRepair(c.Request.Context(), &rep)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+	if oldRep != nil {
+		oldTitle := "Починка, номер VIN: " + oldRep.VIN
+		_ = h.expenses.DeleteByDetails(c.Request.Context(), oldTitle, oldRep.Description, oldRep.Price)
+	}
+
+	var catID int
+	if cat, _ := h.expCats.GetByName(c.Request.Context(), "Ремонт"); cat != nil {
+		catID = cat.ID
+	} else {
+		newCat := models.ExpenseCategory{Name: "Ремонт"}
+		catID, _ = h.expCats.Create(c.Request.Context(), &newCat)
+	}
+
+	exp := models.Expense{
+		Date:        time.Now(),
+		Title:       "Починка, номер VIN: " + rep.VIN,
+		Total:       rep.Price,
+		Description: rep.Description,
+		Paid:        false,
+		CategoryID:  catID,
+	}
+	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
+
 	c.JSON(http.StatusOK, rep)
 }
 
@@ -97,10 +133,17 @@ func (h *RepairHandler) DeleteRepair(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
+	rep, _ := h.service.GetRepairByID(c.Request.Context(), id)
 	err = h.service.DeleteRepair(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+	if rep != nil {
+		title := "Починка, номер VIN: " + rep.VIN
+		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, rep.Description, rep.Price)
+	}
+
 	c.Status(http.StatusNoContent)
 }


### PR DESCRIPTION
## Summary
- ensure repairs expenses use `Ремонт` category
- keep expenses in sync when repairs are updated or deleted

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686167ba1ac8832483577fd917b0dfac