### PR TITLE
Update cashbox on cash payments

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -88,20 +88,10 @@ func Run() {
 	priceSetService := services.NewPriceSetService(priceSetRepo, priceRepo, categoryRepo)
 	priceSetHandler := handlers.NewPriceSetHandler(priceSetService)
 
-	// Бронирования
+	// Бронирования (инициализируем позже, после кассы)
 	bookingItemRepo := repositories.NewBookingItemRepository(db)
 	settingsRepo := repositories.NewSettingsRepository(db)
 	bookingRepo := repositories.NewBookingRepository(db)
-	bookingService := services.NewBookingService(
-		bookingRepo,
-		bookingItemRepo,
-		clientRepo,
-		settingsRepo,
-		priceRepo,
-		priceSetRepo,
-		categoryRepo,
-	)
-	bookingHandler := handlers.NewBookingHandler(bookingService)
 
 	// Категории расходов и сами расходы
 	expCatRepo := repositories.NewExpenseCategoryRepository(db)
@@ -131,6 +121,19 @@ func Run() {
 	cashboxHistRepo := repositories.NewCashboxHistoryRepository(db)
 	cashboxService := services.NewCashboxService(cashboxRepo, cashboxHistRepo, expenseService, expCatService)
 	cashboxHandler := handlers.NewCashboxHandlerCashboxHandler(cashboxService)
+
+	bookingService := services.NewBookingService(
+		bookingRepo,
+		bookingItemRepo,
+		clientRepo,
+		settingsRepo,
+		priceRepo,
+		priceSetRepo,
+		categoryRepo,
+		paymentTypeRepo,
+		cashboxService,
+	)
+	bookingHandler := handlers.NewBookingHandler(bookingService)
 
 	// Настройки
 	settingsRepo = repositories.NewSettingsRepository(db)

--- a/internal/repositories/payment_type_repository.go
+++ b/internal/repositories/payment_type_repository.go
@@ -15,8 +15,17 @@ func NewPaymentTypeRepository(db *sql.DB) *PaymentTypeRepository {
 	return &PaymentTypeRepository{db: db}
 }
 
+func (r *PaymentTypeRepository) GetByID(ctx context.Context, id int) (*models.PaymentType, error) {
+	var pt models.PaymentType
+	err := r.db.QueryRowContext(ctx, `SELECT id, name, hold_percent FROM payment_types WHERE id=?`, id).Scan(&pt.ID, &pt.Name, &pt.HoldPercent)
+	if err != nil {
+		return nil, err
+	}
+	return &pt, nil
+}
+
 func (r *PaymentTypeRepository) GetAll(ctx context.Context) ([]models.PaymentType, error) {
-        rows, err := r.db.QueryContext(ctx, `SELECT id, name, hold_percent FROM payment_types ORDER BY id`)
+	rows, err := r.db.QueryContext(ctx, `SELECT id, name, hold_percent FROM payment_types ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -24,8 +33,8 @@ func (r *PaymentTypeRepository) GetAll(ctx context.Context) ([]models.PaymentTyp
 
 	var result []models.PaymentType
 	for rows.Next() {
-                var pt models.PaymentType
-                if err := rows.Scan(&pt.ID, &pt.Name, &pt.HoldPercent); err != nil {
+		var pt models.PaymentType
+		if err := rows.Scan(&pt.ID, &pt.Name, &pt.HoldPercent); err != nil {
 			return nil, err
 		}
 		result = append(result, pt)
@@ -34,7 +43,7 @@ func (r *PaymentTypeRepository) GetAll(ctx context.Context) ([]models.PaymentTyp
 }
 
 func (r *PaymentTypeRepository) Create(ctx context.Context, pt *models.PaymentType) (int, error) {
-        res, err := r.db.ExecContext(ctx, `INSERT INTO payment_types (name, hold_percent) VALUES (?, ?)`, pt.Name, pt.HoldPercent)
+	res, err := r.db.ExecContext(ctx, `INSERT INTO payment_types (name, hold_percent) VALUES (?, ?)`, pt.Name, pt.HoldPercent)
 	if err != nil {
 		return 0, err
 	}
@@ -43,7 +52,7 @@ func (r *PaymentTypeRepository) Create(ctx context.Context, pt *models.PaymentTy
 }
 
 func (r *PaymentTypeRepository) Update(ctx context.Context, pt *models.PaymentType) error {
-        _, err := r.db.ExecContext(ctx, `UPDATE payment_types SET name=?, hold_percent=? WHERE id=?`, pt.Name, pt.HoldPercent, pt.ID)
+	_, err := r.db.ExecContext(ctx, `UPDATE payment_types SET name=?, hold_percent=? WHERE id=?`, pt.Name, pt.HoldPercent, pt.ID)
 	return err
 }
 

--- a/internal/services/payment_type_service.go
+++ b/internal/services/payment_type_service.go
@@ -30,3 +30,7 @@ func (s *PaymentTypeService) UpdatePaymentType(ctx context.Context, pt *models.P
 func (s *PaymentTypeService) DeletePaymentType(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
+
+func (s *PaymentTypeService) GetPaymentTypeByID(ctx context.Context, id int) (*models.PaymentType, error) {
+	return s.repo.GetByID(ctx, id)
+}


### PR DESCRIPTION
## Summary
- add `GetByID` to payment type repository
- expose `GetPaymentTypeByID` from service
- extend booking service with payment type lookup and cashbox update
- wire cashbox and payment types into booking service

## Testing
- `go vet ./...` *(fails: proxy.golang.org connection forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68663313331c8324acfc64c12bd3bdbd