### PR TITLE
Switch quantity fields to float64

### DIFF
--- a/db/migrations/001_init.up.sql
+++ b/db/migrations/001_init.up.sql
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS booking_items (
                                              id INT AUTO_INCREMENT PRIMARY KEY,
                                              booking_id INT NOT NULL,
                                              item_id INT NOT NULL,
-                                             quantity INT NOT NULL,
+                                             quantity DOUBLE NOT NULL,
                                              price INT NOT NULL,
                                              discount INT DEFAULT 0,
                                              created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/db/migrations/005_pricelist_history.up.sql
+++ b/db/migrations/005_pricelist_history.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS pricelist_history (
     id INT AUTO_INCREMENT PRIMARY KEY,
     price_item_id INT NOT NULL,
-    quantity INT NOT NULL,
+    quantity DOUBLE NOT NULL,
     buy_price DOUBLE NOT NULL,
     total DOUBLE NOT NULL,
     user_id INT,

--- a/internal/models/booking.go
+++ b/internal/models/booking.go
@@ -29,7 +29,7 @@ type BookingItem struct {
 	ID        int     `json:"id"`
 	BookingID int     `json:"booking_id"`
 	ItemID    int     `json:"item_id"`
-	Quantity  int     `json:"quantity"`
+	Quantity  float64 `json:"quantity"`
 	Price     int     `json:"price"`
 	Discount  int     `json:"discount"`
 	ItemPrice float64 `json:"item_price,omitempty"`

--- a/internal/models/price_set.go
+++ b/internal/models/price_set.go
@@ -5,16 +5,16 @@ type PriceSet struct {
 	Name            string    `json:"name"`
 	CategoryID      int       `json:"category_id"`
 	SubcategoryID   int       `json:"subcategory_id"`
-	Quantity        int       `json:"quantity"`
+	Quantity        float64   `json:"quantity"`
 	Price           int       `json:"price"`
 	SubcategoryName string    `json:"subcategory_name,omitempty"`
 	Items           []SetItem `json:"items"`
 }
 
 type SetItem struct {
-	ID         int    `json:"id"`
-	PriceSetID int    `json:"price_set_id"`
-	ItemID     int    `json:"item_id"`
-	Quantity   int    `json:"quantity"`
-	ItemName   string `json:"item_name,omitempty"`
+	ID         int     `json:"id"`
+	PriceSetID int     `json:"price_set_id"`
+	ItemID     int     `json:"item_id"`
+	Quantity   float64 `json:"quantity"`
+	ItemName   string  `json:"item_name,omitempty"`
 }

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -32,7 +32,7 @@ type AdminReportRow struct {
 
 type SaleItem struct {
 	Name     string  `json:"name"`
-	Quantity int     `json:"quantity"`
+	Quantity float64 `json:"quantity"`
 	Revenue  float64 `json:"revenue"`
 	AvgCheck float64 `json:"avg_check"`
 	Category string  `json:"category,omitempty"`
@@ -78,7 +78,7 @@ type DataPoint struct {
 
 type CategoryStat struct {
 	Category string  `json:"category"`
-	Quantity int     `json:"quantity"`
+	Quantity float64 `json:"quantity"`
 	Revenue  float64 `json:"revenue"`
 	AvgCheck float64 `json:"avg_check"`
 }
@@ -106,7 +106,7 @@ type CategorySale struct {
 
 type ProfitItem struct {
 	Name     string  `json:"name"`
-	Quantity int     `json:"quantity"`
+	Quantity float64 `json:"quantity"`
 	Revenue  float64 `json:"revenue"`
 	Expense  float64 `json:"expense"`
 	Profit   float64 `json:"profit"`

--- a/internal/models/stock.go
+++ b/internal/models/stock.go
@@ -6,7 +6,7 @@ type StockHistory struct {
 	ID          int       `json:"id"`
 	Date        time.Time `json:"date"`
 	ItemID      int       `json:"item_id"`
-	Quantity    int       `json:"quantity"`
+	Quantity    float64   `json:"quantity"`
 	BuyPrice    float64   `json:"buy_price"`
 	TotalPrice  float64   `json:"total_price"`
 	UserID      int       `json:"user_id"`

--- a/internal/repositories/report_repository.go
+++ b/internal/repositories/report_repository.go
@@ -570,7 +570,7 @@ func (r *ReportRepository) AnalyticsReport(ctx context.Context, from, to time.Ti
 			avgCheck = revenue / qty
 		}
 		cats = append(cats, models.CategoryStat{
-			Category: name, Quantity: int(qty), Revenue: revenue, AvgCheck: avgCheck,
+			Category: name, Quantity: qty, Revenue: revenue, AvgCheck: avgCheck,
 		})
 	}
 	return &models.AnalyticsReport{

--- a/internal/services/price_item_service.go
+++ b/internal/services/price_item_service.go
@@ -52,7 +52,7 @@ func (s *PriceItemService) AddIncome(ctx context.Context, history *models.PriceI
 		return err
 	}
 	// 2. Увеличиваем остаток в PriceItem
-	return s.repo.IncreaseStock(ctx, history.PriceItemID, float64(history.Quantity))
+	return s.repo.IncreaseStock(ctx, history.PriceItemID, history.Quantity)
 }
 
 // Списание/Продажа товара — запись в истории и уменьшение остатка
@@ -64,7 +64,7 @@ func (s *PriceItemService) AddOutcome(ctx context.Context, history *models.Price
 	if err != nil {
 		return err
 	}
-	return s.repo.DecreaseStock(ctx, history.PriceItemID, float64(history.Quantity))
+	return s.repo.DecreaseStock(ctx, history.PriceItemID, history.Quantity)
 }
 
 // Получить историю по товару

--- a/internal/services/price_set_service.go
+++ b/internal/services/price_set_service.go
@@ -45,7 +45,7 @@ func (s *PriceSetService) CreatePriceSet(ctx context.Context, ps *models.PriceSe
 	}
 	qty, err := s.calculateQuantity(ctx, ps)
 	if err == nil {
-		ps.Quantity = qty
+		ps.Quantity = float64(qty)
 		if err = s.itemRepo.SetStock(ctx, ps.ID, float64(qty)); err != nil {
 			return id, err
 		}
@@ -63,7 +63,7 @@ func (s *PriceSetService) GetAllPriceSets(ctx context.Context) ([]models.PriceSe
 		if err != nil {
 			return nil, err
 		}
-		sets[i].Quantity = qty
+		sets[i].Quantity = float64(qty)
 	}
 	return sets, nil
 }
@@ -75,7 +75,7 @@ func (s *PriceSetService) GetPriceSetByID(ctx context.Context, id int) (*models.
 	}
 	qty, err := s.calculateQuantity(ctx, set)
 	if err == nil {
-		set.Quantity = qty
+		set.Quantity = float64(qty)
 	}
 	return set, nil
 }
@@ -97,7 +97,7 @@ func (s *PriceSetService) UpdatePriceSet(ctx context.Context, ps *models.PriceSe
 	}
 	qty, err := s.calculateQuantity(ctx, ps)
 	if err == nil {
-		ps.Quantity = qty
+		ps.Quantity = float64(qty)
 		if err = s.itemRepo.SetStock(ctx, ps.ID, float64(qty)); err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func (s *PriceSetService) calculateQuantity(ctx context.Context, ps *models.Pric
 		if hours {
 			continue
 		}
-		avail := int(item.Quantity / float64(it.Quantity))
+		avail := int(item.Quantity / it.Quantity)
 		if avail < qty {
 			qty = avail
 		}


### PR DESCRIPTION
## Summary
- change all `quantity` fields in models to `float64`
- adjust services and repositories for the new type
- update migrations to use `DOUBLE` for quantity columns

## Testing
- `go build ./...` *(fails: access to proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866748766b4832488fe85b42a1be864