### PR TITLE
Add repair categories support

### DIFF
--- a/db/migrations/017_repair_categories.up.sql
+++ b/db/migrations/017_repair_categories.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS repair_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+ALTER TABLE repairs
+    ADD COLUMN category_id INT,
+    ADD FOREIGN KEY (category_id) REFERENCES repair_categories(id) ON DELETE SET NULL;
+
+ALTER TABLE expenses
+    ADD COLUMN repair_category_id INT,
+    ADD FOREIGN KEY (repair_category_id) REFERENCES repair_categories(id) ON DELETE SET NULL;

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -98,6 +98,11 @@ func Run() {
 	expCatService := services.NewExpenseCategoryService(expCatRepo)
 	expCatHandler := handlers.NewExpenseCategoryHandler(expCatService)
 
+	// Категории ремонтов
+	repCatRepo := repositories.NewRepairCategoryRepository(db)
+	repCatService := services.NewRepairCategoryService(repCatRepo)
+	repCatHandler := handlers.NewRepairCategoryHandler(repCatService)
+
 	expenseRepo := repositories.NewExpenseRepository(db)
 	expenseService := services.NewExpenseService(expenseRepo)
 	expenseHandler := handlers.NewExpenseHandler(expenseService)
@@ -168,6 +173,7 @@ func Run() {
 		plHistoryHandler,
 		priceSetHandler,
 		repairHandler,
+		repCatHandler,
 		cashboxHandler,
 		settingsHandler,
 		reportHandler,

--- a/internal/handlers/pricelist_history_handler.go
+++ b/internal/handlers/pricelist_history_handler.go
@@ -91,7 +91,7 @@ func (h *PricelistHistoryHandler) Delete(c *gin.Context) {
 	if item != nil {
 		title := "Пополнение " + item.Name
 		desc := "Пополнение товара " + item.Name + " в количестве " + strconv.FormatFloat(hist.Quantity, 'f', -1, 64) + " шт."
-		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, desc, hist.Total)
+		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, desc, hist.Total, 0)
 	}
 	c.Status(http.StatusNoContent)
 }

--- a/internal/handlers/repair_category_handler.go
+++ b/internal/handlers/repair_category_handler.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/services"
+)
+
+type RepairCategoryHandler struct {
+	service *services.RepairCategoryService
+}
+
+func NewRepairCategoryHandler(s *services.RepairCategoryService) *RepairCategoryHandler {
+	return &RepairCategoryHandler{service: s}
+}
+
+func (h *RepairCategoryHandler) Create(c *gin.Context) {
+	var cat models.RepairCategory
+	if err := c.ShouldBindJSON(&cat); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	id, err := h.service.Create(c.Request.Context(), &cat)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	cat.ID = id
+	c.JSON(http.StatusCreated, cat)
+}
+
+func (h *RepairCategoryHandler) GetAll(c *gin.Context) {
+	cats, err := h.service.GetAll(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, cats)
+}
+
+func (h *RepairCategoryHandler) Update(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var cat models.RepairCategory
+	if err := c.ShouldBindJSON(&cat); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	cat.ID = id
+	if err := h.service.Update(c.Request.Context(), &cat); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, cat)
+}
+
+func (h *RepairCategoryHandler) Delete(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/repair_handler.go
+++ b/internal/handlers/repair_handler.go
@@ -43,12 +43,13 @@ func (h *RepairHandler) CreateRepair(c *gin.Context) {
 	}
 
 	exp := models.Expense{
-		Date:        time.Now(),
-		Title:       "Починка, номер VIN: " + rep.VIN,
-		Total:       rep.Price,
-		Description: rep.Description,
-		Paid:        false,
-		CategoryID:  catID,
+		Date:             time.Now(),
+		Title:            "Починка, номер VIN: " + rep.VIN,
+		Total:            rep.Price,
+		Description:      rep.Description,
+		Paid:             false,
+		CategoryID:       catID,
+		RepairCategoryID: rep.CategoryID,
 	}
 	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
 
@@ -102,7 +103,7 @@ func (h *RepairHandler) UpdateRepair(c *gin.Context) {
 
 	if oldRep != nil {
 		oldTitle := "Починка, номер VIN: " + oldRep.VIN
-		_ = h.expenses.DeleteByDetails(c.Request.Context(), oldTitle, oldRep.Description, oldRep.Price)
+		_ = h.expenses.DeleteByDetails(c.Request.Context(), oldTitle, oldRep.Description, oldRep.Price, oldRep.CategoryID)
 	}
 
 	var catID int
@@ -114,12 +115,13 @@ func (h *RepairHandler) UpdateRepair(c *gin.Context) {
 	}
 
 	exp := models.Expense{
-		Date:        time.Now(),
-		Title:       "Починка, номер VIN: " + rep.VIN,
-		Total:       rep.Price,
-		Description: rep.Description,
-		Paid:        false,
-		CategoryID:  catID,
+		Date:             time.Now(),
+		Title:            "Починка, номер VIN: " + rep.VIN,
+		Total:            rep.Price,
+		Description:      rep.Description,
+		Paid:             false,
+		CategoryID:       catID,
+		RepairCategoryID: rep.CategoryID,
 	}
 	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
 
@@ -142,7 +144,7 @@ func (h *RepairHandler) DeleteRepair(c *gin.Context) {
 
 	if rep != nil {
 		title := "Починка, номер VIN: " + rep.VIN
-		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, rep.Description, rep.Price)
+		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, rep.Description, rep.Price, rep.CategoryID)
 	}
 
 	c.Status(http.StatusNoContent)

--- a/internal/models/expense.go
+++ b/internal/models/expense.go
@@ -3,13 +3,15 @@ package models
 import "time"
 
 type Expense struct {
-	ID          int       `json:"id"`
-	Date        time.Time `json:"date"`
-	Title       string    `json:"title"`
-	CategoryID  int       `json:"category_id,omitempty"`
-	Category    string    `json:"category"`
-	Total       float64   `json:"total"`
-	Description string    `json:"description"`
-	Paid        bool      `json:"paid"`
-	CreatedAt   time.Time `json:"created_at"`
+	ID               int       `json:"id"`
+	Date             time.Time `json:"date"`
+	Title            string    `json:"title"`
+	CategoryID       int       `json:"category_id,omitempty"`
+	Category         string    `json:"category"`
+	RepairCategoryID int       `json:"repair_category_id,omitempty"`
+	RepairCategory   string    `json:"repair_category"`
+	Total            float64   `json:"total"`
+	Description      string    `json:"description"`
+	Paid             bool      `json:"paid"`
+	CreatedAt        time.Time `json:"created_at"`
 }

--- a/internal/models/repair.go
+++ b/internal/models/repair.go
@@ -6,6 +6,8 @@ type Repair struct {
 	ID          int       `json:"id"`
 	Date        time.Time `json:"date"`
 	VIN         string    `json:"vin"`
+	CategoryID  int       `json:"category_id,omitempty"`
+	Category    string    `json:"category"`
 	Description string    `json:"description"`
 	Price       float64   `json:"price"`
 	CreatedAt   time.Time `json:"created_at"`

--- a/internal/models/repair_category.go
+++ b/internal/models/repair_category.go
@@ -1,0 +1,6 @@
+package models
+
+type RepairCategory struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}

--- a/internal/repositories/repair_category_repository.go
+++ b/internal/repositories/repair_category_repository.go
@@ -1,0 +1,63 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"psclub-crm/internal/models"
+)
+
+type RepairCategoryRepository struct {
+	db *sql.DB
+}
+
+func NewRepairCategoryRepository(db *sql.DB) *RepairCategoryRepository {
+	return &RepairCategoryRepository{db: db}
+}
+
+func (r *RepairCategoryRepository) Create(ctx context.Context, c *models.RepairCategory) (int, error) {
+	res, err := r.db.ExecContext(ctx, `INSERT INTO repair_categories (name) VALUES (?)`, c.Name)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *RepairCategoryRepository) GetAll(ctx context.Context) ([]models.RepairCategory, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, name FROM repair_categories ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var list []models.RepairCategory
+	for rows.Next() {
+		var c models.RepairCategory
+		if err := rows.Scan(&c.ID, &c.Name); err != nil {
+			return nil, err
+		}
+		list = append(list, c)
+	}
+	return list, nil
+}
+
+func (r *RepairCategoryRepository) Update(ctx context.Context, c *models.RepairCategory) error {
+	_, err := r.db.ExecContext(ctx, `UPDATE repair_categories SET name=? WHERE id=?`, c.Name, c.ID)
+	return err
+}
+
+func (r *RepairCategoryRepository) Delete(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM repair_categories WHERE id=?`, id)
+	return err
+}
+
+func (r *RepairCategoryRepository) GetByName(ctx context.Context, name string) (*models.RepairCategory, error) {
+	var c models.RepairCategory
+	err := r.db.QueryRowContext(ctx, `SELECT id, name FROM repair_categories WHERE name=?`, name).Scan(&c.ID, &c.Name)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}

--- a/internal/repositories/report_repository.go
+++ b/internal/repositories/report_repository.go
@@ -449,9 +449,10 @@ func (r *ReportRepository) SalesReport(ctx context.Context, from, to time.Time, 
 
 	condExp, expArgs := buildTimeCondition("e.date", from, to, tFrom, tTo)
 	expQuery := fmt.Sprintf(`
-        SELECT IFNULL(ec.name, e.category_id) as category, SUM(e.total)
+        SELECT IFNULL(ec.name, IFNULL(rc.name, e.category_id)) as category, SUM(e.total)
         FROM expenses e
         LEFT JOIN expense_categories ec ON e.category_id = ec.id
+        LEFT JOIN repair_categories rc ON e.repair_category_id = rc.id
         WHERE %s
         GROUP BY category`, condExp)
 	expRows, err := r.db.QueryContext(ctx, expQuery, expArgs...)

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -23,6 +23,7 @@ func SetupRoutes(
 	pricelistHistoryHandler *handlers.PricelistHistoryHandler,
 	priceSetHandler *handlers.PriceSetHandler,
 	repairHandler *handlers.RepairHandler,
+	repairCatHandler *handlers.RepairCategoryHandler,
 	cashboxHandler *handlers.CashboxHandler,
 	settingsHandler *handlers.SettingsHandler,
 	reportHandler *handlers.ReportHandler,
@@ -171,6 +172,15 @@ func SetupRoutes(
 		expenseCats.GET("", expCatHandler.GetAll)
 		expenseCats.PUT("/:id", expCatHandler.Update)
 		expenseCats.DELETE("/:id", expCatHandler.Delete)
+	}
+
+	// --- Категории ремонтов
+	repairCats := api.Group("/repair-categories")
+	{
+		repairCats.POST("", repairCatHandler.Create)
+		repairCats.GET("", repairCatHandler.GetAll)
+		repairCats.PUT("/:id", repairCatHandler.Update)
+		repairCats.DELETE("/:id", repairCatHandler.Delete)
 	}
 
 	// --- Расходы

--- a/internal/services/expense_service.go
+++ b/internal/services/expense_service.go
@@ -34,6 +34,6 @@ func (s *ExpenseService) DeleteExpense(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
 
-func (s *ExpenseService) DeleteByDetails(ctx context.Context, title, description string, total float64) error {
-	return s.repo.DeleteByDetails(ctx, title, description, total)
+func (s *ExpenseService) DeleteByDetails(ctx context.Context, title, description string, total float64, repairCategoryID int) error {
+	return s.repo.DeleteByDetails(ctx, title, description, total, repairCategoryID)
 }

--- a/internal/services/repair_category_service.go
+++ b/internal/services/repair_category_service.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"context"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/repositories"
+)
+
+type RepairCategoryService struct {
+	repo *repositories.RepairCategoryRepository
+}
+
+func NewRepairCategoryService(r *repositories.RepairCategoryRepository) *RepairCategoryService {
+	return &RepairCategoryService{repo: r}
+}
+
+func (s *RepairCategoryService) Create(ctx context.Context, c *models.RepairCategory) (int, error) {
+	return s.repo.Create(ctx, c)
+}
+
+func (s *RepairCategoryService) GetAll(ctx context.Context) ([]models.RepairCategory, error) {
+	return s.repo.GetAll(ctx)
+}
+
+func (s *RepairCategoryService) Update(ctx context.Context, c *models.RepairCategory) error {
+	return s.repo.Update(ctx, c)
+}
+
+func (s *RepairCategoryService) Delete(ctx context.Context, id int) error {
+	return s.repo.Delete(ctx, id)
+}
+
+func (s *RepairCategoryService) GetByName(ctx context.Context, name string) (*models.RepairCategory, error) {
+	return s.repo.GetByName(ctx, name)
+}


### PR DESCRIPTION
## Summary
- introduce `repair_categories` table and migration
- extend `repairs` and `expenses` with repair category references
- add CRUD for repair categories
- update repair, expense logic and reports to use repair categories
- wire up new routes and services

## Testing
- `go vet ./...` *(fails: access to proxy.golang.org blocked)*
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686baef663d48324b3bb2666ba8eaa89