### PR TITLE
Implement date filter in expenses endpoint

### DIFF
--- a/internal/handlers/expense_handler.go
+++ b/internal/handlers/expense_handler.go
@@ -34,7 +34,8 @@ func (h *ExpenseHandler) CreateExpense(c *gin.Context) {
 
 // GET /api/expenses
 func (h *ExpenseHandler) GetAllExpenses(c *gin.Context) {
-	expenses, err := h.service.GetAllExpenses(c.Request.Context())
+	from, to, _, _ := getPeriod(c)
+	expenses, err := h.service.GetAllExpenses(c.Request.Context(), from, to)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/repositories/expense_repository.go
+++ b/internal/repositories/expense_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"psclub-crm/internal/models"
+	"time"
 )
 
 type ExpenseRepository struct {
@@ -25,13 +26,14 @@ func (r *ExpenseRepository) Create(ctx context.Context, e *models.Expense) (int,
 	return int(id), err
 }
 
-func (r *ExpenseRepository) GetAll(ctx context.Context) ([]models.Expense, error) {
+func (r *ExpenseRepository) GetAll(ctx context.Context, from, to time.Time) ([]models.Expense, error) {
 	query := `SELECT e.id, e.date, e.title, e.category_id, IFNULL(ec.name, ''), e.repair_category_id, IFNULL(rc.name,''), e.total, e.description, e.paid, e.created_at
                 FROM expenses e
                 LEFT JOIN expense_categories ec ON e.category_id = ec.id
                 LEFT JOIN repair_categories rc ON e.repair_category_id = rc.id
+                WHERE DATE(e.date) BETWEEN ? AND ?
                 ORDER BY e.id DESC`
-	rows, err := r.db.QueryContext(ctx, query)
+	rows, err := r.db.QueryContext(ctx, query, from, to)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/expense_service.go
+++ b/internal/services/expense_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
+	"time"
 )
 
 type ExpenseService struct {
@@ -18,8 +19,8 @@ func (s *ExpenseService) CreateExpense(ctx context.Context, e *models.Expense) (
 	return s.repo.Create(ctx, e)
 }
 
-func (s *ExpenseService) GetAllExpenses(ctx context.Context) ([]models.Expense, error) {
-	return s.repo.GetAll(ctx)
+func (s *ExpenseService) GetAllExpenses(ctx context.Context, from, to time.Time) ([]models.Expense, error) {
+	return s.repo.GetAll(ctx, from, to)
 }
 
 func (s *ExpenseService) GetExpenseByID(ctx context.Context, id int) (*models.Expense, error) {


### PR DESCRIPTION
## Summary
- extend `GetAllExpenses` to accept `from` and `to` query parameters
- plumb date range into service and repository layer

## Testing
- `go vet ./...` *(fails: access denied)*
- `go build ./...` *(fails: access denied)*

------
https://chatgpt.com/codex/tasks/task_e_686bb8a479fc8324ba5300deaa935685