### PR TITLE
Fix NULL categories in report queries

### DIFF
--- a/internal/repositories/expense_repository.go
+++ b/internal/repositories/expense_repository.go
@@ -27,7 +27,7 @@ func (r *ExpenseRepository) Create(ctx context.Context, e *models.Expense) (int,
 }
 
 func (r *ExpenseRepository) GetAll(ctx context.Context, from, to time.Time) ([]models.Expense, error) {
-	query := `SELECT e.id, e.date, e.title, e.category_id, IFNULL(ec.name, ''), e.repair_category_id, IFNULL(rc.name,''), e.total, e.description, e.paid, e.created_at
+	query := `SELECT e.id, e.date, e.title, IFNULL(e.category_id, 0), IFNULL(ec.name, ''), IFNULL(e.repair_category_id, 0), IFNULL(rc.name,''), e.total, e.description, e.paid, e.created_at
                 FROM expenses e
                 LEFT JOIN expense_categories ec ON e.category_id = ec.id
                 LEFT JOIN repair_categories rc ON e.repair_category_id = rc.id
@@ -51,7 +51,7 @@ func (r *ExpenseRepository) GetAll(ctx context.Context, from, to time.Time) ([]m
 }
 
 func (r *ExpenseRepository) GetByID(ctx context.Context, id int) (*models.Expense, error) {
-	query := `SELECT e.id, e.date, e.title, e.category_id, IFNULL(ec.name, ''), e.repair_category_id, IFNULL(rc.name,''), e.total, e.description, e.paid, e.created_at
+	query := `SELECT e.id, e.date, e.title, IFNULL(e.category_id, 0), IFNULL(ec.name, ''), IFNULL(e.repair_category_id, 0), IFNULL(rc.name,''), e.total, e.description, e.paid, e.created_at
                 FROM expenses e
                 LEFT JOIN expense_categories ec ON e.category_id = ec.id
                 LEFT JOIN repair_categories rc ON e.repair_category_id = rc.id

--- a/internal/repositories/repair_repository.go
+++ b/internal/repositories/repair_repository.go
@@ -26,7 +26,7 @@ func (r *RepairRepository) Create(ctx context.Context, rep *models.Repair) (int,
 }
 
 func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) {
-	query := `SELECT r.id, r.date, r.vin, r.description, r.price, r.category_id, IFNULL(rc.name, ''), r.created_at, r.updated_at
+	query := `SELECT r.id, r.date, r.vin, r.description, r.price, IFNULL(r.category_id, 0), IFNULL(rc.name, ''), r.created_at, r.updated_at
                 FROM repairs r
                 LEFT JOIN repair_categories rc ON r.category_id = rc.id
                 ORDER BY r.id DESC`
@@ -48,7 +48,7 @@ func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) 
 }
 
 func (r *RepairRepository) GetByID(ctx context.Context, id int) (*models.Repair, error) {
-	query := `SELECT r.id, r.date, r.vin, r.description, r.price, r.category_id, IFNULL(rc.name,''), r.created_at, r.updated_at
+	query := `SELECT r.id, r.date, r.vin, r.description, r.price, IFNULL(r.category_id, 0), IFNULL(rc.name,''), r.created_at, r.updated_at
                 FROM repairs r
                 LEFT JOIN repair_categories rc ON r.category_id = rc.id
                 WHERE r.id = ?`

--- a/internal/repositories/report_repository.go
+++ b/internal/repositories/report_repository.go
@@ -449,8 +449,8 @@ func (r *ReportRepository) SalesReport(ctx context.Context, from, to time.Time, 
 
 	condExp, expArgs := buildTimeCondition("e.date", from, to, tFrom, tTo)
 	expQuery := fmt.Sprintf(`
-        SELECT IFNULL(ec.name, IFNULL(rc.name, e.category_id)) as category, SUM(e.total)
-        FROM expenses e
+       SELECT IFNULL(ec.name, IFNULL(rc.name, '')) as category, SUM(e.total)
+       FROM expenses e
         LEFT JOIN expense_categories ec ON e.category_id = ec.id
         LEFT JOIN repair_categories rc ON e.repair_category_id = rc.id
         WHERE %s


### PR DESCRIPTION
## Summary
- ensure expenses report returns empty category names when both category and repair category names are absent

## Testing
- `go test ./...` *(fails: fetching modules requires internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686cc05aeac48324a93754edc9649b50