### PR TITLE
Localize cashbox operations

### DIFF
--- a/internal/services/booking_service.go
+++ b/internal/services/booking_service.go
@@ -137,7 +137,7 @@ func (s *BookingService) CreateBooking(ctx context.Context, b *models.Booking) (
 			}
 			name := strings.ToLower(pt.Name)
 			if strings.Contains(name, "наличными") {
-				_ = s.cashboxService.Replenish(ctx, float64(p.Amount))
+				_ = s.cashboxService.AddIncome(ctx, float64(p.Amount))
 			}
 		}
 	}

--- a/internal/services/cashbox_service.go
+++ b/internal/services/cashbox_service.go
@@ -38,7 +38,7 @@ func (s *CashboxService) Inventory(ctx context.Context) error {
 		return err
 	}
 	hist := models.CashboxHistory{
-		Operation: "INVENTORY",
+		Operation: "Инвентаризация",
 		Amount:    box.Amount,
 	}
 	if _, err := s.histRepo.Create(ctx, &hist); err != nil {
@@ -59,7 +59,7 @@ func (s *CashboxService) AddIncome(ctx context.Context, amount float64) error {
 		return err
 	}
 	hist := models.CashboxHistory{
-		Operation: "BOOKING_PAYMENT",
+		Operation: "Оплата брони",
 		Amount:    amount,
 	}
 	if _, err := s.histRepo.Create(ctx, &hist); err != nil {
@@ -79,7 +79,7 @@ func (s *CashboxService) RemoveIncome(ctx context.Context, amount float64) error
 		return err
 	}
 	hist := models.CashboxHistory{
-		Operation: "BOOKING_REFUND",
+		Operation: "Возврат брони",
 		Amount:    -amount,
 	}
 	if _, err := s.histRepo.Create(ctx, &hist); err != nil {
@@ -99,7 +99,7 @@ func (s *CashboxService) Replenish(ctx context.Context, amount float64) error {
 		return err
 	}
 	hist := models.CashboxHistory{
-		Operation: "REPLENISH",
+		Operation: "Пополнение",
 		Amount:    amount,
 	}
 	if _, err := s.histRepo.Create(ctx, &hist); err != nil {


### PR DESCRIPTION
## Summary
- localize cashbox history operation names to Russian
- treat cash payments as income without creating an expense

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a2d6df9188324b7f43801da639019