### PR TITLE
Add clientless booking support

### DIFF
--- a/db/migrations/021_booking_nullable_client.up.sql
+++ b/db/migrations/021_booking_nullable_client.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookings MODIFY client_id INT NULL;

--- a/internal/handlers/cashbox_handler.go
+++ b/internal/handlers/cashbox_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
+	"io"
 	"net/http"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
@@ -42,7 +43,20 @@ func (h *CashboxHandler) UpdateCashbox(c *gin.Context) {
 
 // POST /api/cashbox/inventory
 func (h *CashboxHandler) Inventory(c *gin.Context) {
-	if err := h.service.Inventory(c.Request.Context()); err != nil {
+	var req struct {
+		Amount *float64 `json:"amount"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil && err != io.EOF {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	var err error
+	if req.Amount != nil {
+		err = h.service.InventoryAmount(c.Request.Context(), *req.Amount)
+	} else {
+		err = h.service.Inventory(c.Request.Context())
+	}
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
## Summary
- allow creating bookings without assigning a client
- update repository queries to handle NULL client_id
- skip client bonus operations when booking is clientless
- add migration to make booking client_id nullable

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e0a44b10083248c06e70da1067858