### PR TITLE
Enable migrations at startup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"psclub-crm/internal/config"
 	"psclub-crm/internal/handlers"
 	"psclub-crm/internal/middleware"
+	"psclub-crm/internal/migrations"
 	"psclub-crm/internal/repositories"
 	"psclub-crm/internal/routes"
 	"psclub-crm/internal/services"
@@ -25,6 +26,10 @@ func Run() {
 		log.Fatal("Failed to connect to DB: ", err)
 	}
 	defer db.Close()
+
+	if err := migrations.Run(db, "./migrations"); err != nil {
+		log.Fatalf("migrations run error: %v", err)
+	}
 	// ========== Инициализация зависимостей ==========
 
 	// Клиенты


### PR DESCRIPTION
## Summary
- run migrations automatically when the application starts

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f8e62ce5083249fa249b96629f35d