### PR TITLE
Add client channel stats to summary report

### DIFF
--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -11,6 +11,7 @@ type SummaryReport struct {
 	Age36Plus      float64        `json:"age_36_plus_percent"`
 	CategorySales  []CategorySale `json:"category_sales"`
 	TopItems       []ProfitItem   `json:"top_items"`
+	ChannelStats   []ChannelStat  `json:"channel_stats"`
 	RevenueChange  float64        `json:"revenue_change_percent"`
 	ClientsChange  float64        `json:"clients_change_percent"`
 	AvgCheckChange float64        `json:"avg_check_change_percent"`
@@ -111,4 +112,9 @@ type ProfitItem struct {
 	Revenue  float64 `json:"revenue"`
 	Expense  float64 `json:"expense"`
 	Profit   float64 `json:"profit"`
+}
+
+type ChannelStat struct {
+	Channel string `json:"channel"`
+	Clients int    `json:"clients"`
 }


### PR DESCRIPTION
## Summary
- extend `SummaryReport` with list of client acquisition channels
- compute channel stats in `SummaryReport` repository query

## Testing
- `go test ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687f95a3eb588324b6a272d43fc1b842