### PR TITLE
Allow negative stock adjustments

### DIFF
--- a/internal/repositories/price_item_repository.go
+++ b/internal/repositories/price_item_repository.go
@@ -93,19 +93,9 @@ func (r *PriceItemRepository) UpdateBuyPrice(ctx context.Context, id int, price 
 
 // При продаже/списании уменьшаем остаток
 func (r *PriceItemRepository) DecreaseStock(ctx context.Context, id int, amount float64) error {
-	query := `UPDATE price_items SET quantity = quantity - ? WHERE id = ? AND quantity >= ?`
-	res, err := r.db.ExecContext(ctx, query, amount, id, amount)
-	if err != nil {
-		return err
-	}
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
-		return sql.ErrNoRows // недостаточно на складе
-	}
-	return nil
+	query := `UPDATE price_items SET quantity = quantity - ? WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, amount, id)
+	return err
 }
 
 // SetStock overrides the current quantity with the provided value.

--- a/internal/services/booking_service.go
+++ b/internal/services/booking_service.go
@@ -471,6 +471,7 @@ func (s *BookingService) checkStock(ctx context.Context, items []models.BookingI
 		if isHours {
 			continue
 		}
+
 		if pi.IsSet {
 			set, err := s.priceSetRepo.GetByID(ctx, pi.ID)
 			if err != nil {
@@ -482,29 +483,6 @@ func (s *BookingService) checkStock(ctx context.Context, items []models.BookingI
 			}
 			if err := s.priceItemRepo.SetStock(ctx, set.ID, float64(qty)); err != nil {
 				return err
-			}
-			if qty < it.Quantity {
-				return errors.New("insufficient stock 1")
-			}
-			for _, si := range set.Items {
-				sub, err := s.priceItemRepo.GetByID(ctx, si.ItemID)
-				if err != nil {
-					return err
-				}
-				hoursSub, err := s.isHoursCategory(ctx, sub.CategoryID)
-				if err != nil {
-					return err
-				}
-				if hoursSub {
-					continue
-				}
-				if sub.Quantity < si.Quantity*it.Quantity {
-					return errors.New("insufficient stock 2")
-				}
-			}
-		} else {
-			if pi.Quantity < it.Quantity {
-				return errors.New("insufficient stock 1")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- permit stock to go negative when decreasing quantity
- remove strict stock checks during booking creation and updates

## Testing
- `go test ./...` *(fails: cannot fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_68873361c9208324a9e43305ccebb925