### PR TITLE
Add cashbox day endpoint

### DIFF
--- a/internal/handlers/cashbox_handler.go
+++ b/internal/handlers/cashbox_handler.go
@@ -88,3 +88,13 @@ func (h *CashboxHandler) GetHistory(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, list)
 }
+
+// GET /api/cashbox/day
+func (h *CashboxHandler) GetDay(c *gin.Context) {
+	start, list, err := h.service.GetDay(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"start_amount": start, "history": list})
+}

--- a/internal/repositories/cashbox_history_repository.go
+++ b/internal/repositories/cashbox_history_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"time"
+
 	"psclub-crm/internal/models"
 )
 
@@ -26,6 +28,25 @@ func (r *CashboxHistoryRepository) Create(ctx context.Context, h *models.Cashbox
 
 func (r *CashboxHistoryRepository) GetAll(ctx context.Context) ([]models.CashboxHistory, error) {
 	rows, err := r.db.QueryContext(ctx, `SELECT id, operation, amount, created_at FROM cashbox_history ORDER BY id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var list []models.CashboxHistory
+	for rows.Next() {
+		var h models.CashboxHistory
+		if err := rows.Scan(&h.ID, &h.Operation, &h.Amount, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		list = append(list, h)
+	}
+	return list, nil
+}
+
+func (r *CashboxHistoryRepository) GetByDate(ctx context.Context, date time.Time) ([]models.CashboxHistory, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, operation, amount, created_at FROM cashbox_history WHERE DATE(created_at)=? ORDER BY id`,
+		date.Format("2006-01-02"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -228,6 +228,7 @@ func SetupRoutes(
 	cashbox := api.Group("/cashbox")
 	{
 		cashbox.GET("", cashboxHandler.GetCashbox)
+		cashbox.GET("/day", cashboxHandler.GetDay)
 		cashbox.PUT("/:id", cashboxHandler.UpdateCashbox)
 		cashbox.POST("/inventory", cashboxHandler.Inventory)
 		cashbox.POST("/replenish", cashboxHandler.Replenish)

--- a/internal/services/cashbox_service.go
+++ b/internal/services/cashbox_service.go
@@ -137,3 +137,22 @@ func (s *CashboxService) Replenish(ctx context.Context, amount float64) error {
 func (s *CashboxService) GetHistory(ctx context.Context) ([]models.CashboxHistory, error) {
 	return s.histRepo.GetAll(ctx)
 }
+
+// GetDay returns cashbox amount at start of current day and history records for today
+func (s *CashboxService) GetDay(ctx context.Context) (float64, []models.CashboxHistory, error) {
+	today := time.Now()
+	list, err := s.histRepo.GetByDate(ctx, today)
+	if err != nil {
+		return 0, nil, err
+	}
+	box, err := s.repo.Get(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	var sum float64
+	for _, h := range list {
+		sum += h.Amount
+	}
+	start := box.Amount - sum
+	return start, list, nil
+}


### PR DESCRIPTION
## Summary
- add endpoint to read today's cashbox operations
- support fetching history records by date

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688740d16ce48324848f2840ca3a6f19