### PR TITLE
Adjust cashbox day to follow configured work time

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -132,7 +132,7 @@ func Run() {
 	// Касса
 	cashboxRepo := repositories.NewCashboxRepository(db)
 	cashboxHistRepo := repositories.NewCashboxHistoryRepository(db)
-	cashboxService := services.NewCashboxService(cashboxRepo, cashboxHistRepo, expenseService, expCatService)
+	cashboxService := services.NewCashboxService(cashboxRepo, cashboxHistRepo, expenseService, expCatService, settingsRepo)
 	cashboxHandler := handlers.NewCashboxHandlerCashboxHandler(cashboxService)
 
 	bookingService := services.NewBookingService(

--- a/internal/repositories/cashbox_history_repository.go
+++ b/internal/repositories/cashbox_history_repository.go
@@ -61,3 +61,22 @@ func (r *CashboxHistoryRepository) GetByDate(ctx context.Context, date time.Time
 	}
 	return list, nil
 }
+
+func (r *CashboxHistoryRepository) GetByPeriod(ctx context.Context, start, end time.Time) ([]models.CashboxHistory, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, operation, amount, created_at FROM cashbox_history WHERE created_at >= ? AND created_at < ? ORDER BY id`,
+		start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var list []models.CashboxHistory
+	for rows.Next() {
+		var h models.CashboxHistory
+		if err := rows.Scan(&h.ID, &h.Operation, &h.Amount, &h.CreatedAt); err != nil {
+			return nil, err
+		}
+		list = append(list, h)
+	}
+	return list, nil
+}


### PR DESCRIPTION
## Summary
- use work-time range from settings when calculating cashbox day
- expose repository method to get history records by time period
- wire settings repo into cashbox service

## Testing
- `go build ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a13e5952483249321b29ae06087b0