### PR TITLE
Add tenant-aware expense categories and JWT context checks

### DIFF
--- a/internal/handlers/cashbox_handler.go
+++ b/internal/handlers/cashbox_handler.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"context"
 	"github.com/gin-gonic/gin"
 	"io"
 	"net/http"
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
 )
@@ -18,7 +20,11 @@ func NewCashboxHandlerCashboxHandler(service *services.CashboxService) *CashboxH
 
 // GET /api/cashbox
 func (h *CashboxHandler) GetCashbox(c *gin.Context) {
-	box, err := h.service.GetCashbox(c.Request.Context())
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	box, err := h.service.GetCashbox(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -33,7 +39,11 @@ func (h *CashboxHandler) UpdateCashbox(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	err := h.service.UpdateCashbox(c.Request.Context(), &box)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	err := h.service.UpdateCashbox(ctx, &box)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -50,11 +60,15 @@ func (h *CashboxHandler) Inventory(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
 	var err error
 	if req.Amount != nil {
-		err = h.service.InventoryAmount(c.Request.Context(), *req.Amount)
+		err = h.service.InventoryAmount(ctx, *req.Amount)
 	} else {
-		err = h.service.Inventory(c.Request.Context())
+		err = h.service.Inventory(ctx)
 	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -72,7 +86,11 @@ func (h *CashboxHandler) Replenish(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.Replenish(c.Request.Context(), req.Amount); err != nil {
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Replenish(ctx, req.Amount); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -81,7 +99,11 @@ func (h *CashboxHandler) Replenish(c *gin.Context) {
 
 // GET /api/cashbox/history
 func (h *CashboxHandler) GetHistory(c *gin.Context) {
-	list, err := h.service.GetHistory(c.Request.Context())
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	list, err := h.service.GetHistory(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -91,7 +113,11 @@ func (h *CashboxHandler) GetHistory(c *gin.Context) {
 
 // GET /api/cashbox/day
 func (h *CashboxHandler) GetDay(c *gin.Context) {
-	start, list, err := h.service.GetDay(c.Request.Context())
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	start, list, err := h.service.GetDay(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/handlers/expense_category_handler.go
+++ b/internal/handlers/expense_category_handler.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
 )
@@ -23,7 +25,13 @@ func (h *ExpenseCategoryHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	id, err := h.service.Create(c.Request.Context(), &cat)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	cat.CompanyID = companyID
+	cat.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	id, err := h.service.Create(ctx, &cat)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -33,7 +41,11 @@ func (h *ExpenseCategoryHandler) Create(c *gin.Context) {
 }
 
 func (h *ExpenseCategoryHandler) GetAll(c *gin.Context) {
-	cats, err := h.service.GetAll(c.Request.Context())
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	cats, err := h.service.GetAll(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -52,8 +64,14 @@ func (h *ExpenseCategoryHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
 	cat.ID = id
-	if err := h.service.Update(c.Request.Context(), &cat); err != nil {
+	cat.CompanyID = companyID
+	cat.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Update(ctx, &cat); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -66,7 +84,11 @@ func (h *ExpenseCategoryHandler) Delete(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Delete(ctx, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/handlers/price_item_handler.go
+++ b/internal/handlers/price_item_handler.go
@@ -296,11 +296,11 @@ func (h *PriceItemHandler) Replenish(c *gin.Context) {
 	cat, _ := h.categories.GetCategoryByID(c.Request.Context(), item.CategoryID, companyID, branchID)
 	var expCatID int
 	if cat != nil {
-		if ec, _ := h.expCats.GetByName(c.Request.Context(), cat.Name); ec != nil {
+		if ec, _ := h.expCats.GetByName(ctx, cat.Name); ec != nil {
 			expCatID = ec.ID
 		} else {
-			newCat := models.ExpenseCategory{Name: cat.Name}
-			expCatID, _ = h.expCats.Create(c.Request.Context(), &newCat)
+			newCat := models.ExpenseCategory{Name: cat.Name, CompanyID: companyID, BranchID: branchID}
+			expCatID, _ = h.expCats.Create(ctx, &newCat)
 		}
 	}
 
@@ -312,7 +312,7 @@ func (h *PriceItemHandler) Replenish(c *gin.Context) {
 		CategoryID:  expCatID,
 		Description: "Пополнение товара " + item.Name + " в количестве " + strconv.FormatFloat(in.Quantity, 'f', -1, 64) + " шт.",
 	}
-	_, _ = h.expenses.CreateExpense(c.Request.Context(), &exp)
+	_, _ = h.expenses.CreateExpense(ctx, &exp)
 
 	c.JSON(http.StatusOK, gin.H{"status": "success"})
 }

--- a/internal/models/expense_category.go
+++ b/internal/models/expense_category.go
@@ -1,6 +1,8 @@
 package models
 
 type ExpenseCategory struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	CompanyID int    `json:"company_id"`
+	BranchID  int    `json:"branch_id"`
 }

--- a/internal/services/cashbox_service.go
+++ b/internal/services/cashbox_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
 )
@@ -118,11 +119,13 @@ func (s *CashboxService) Replenish(ctx context.Context, amount float64) error {
 		return err
 	}
 
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
 	var catID int
 	if cat, _ := s.expCatSvc.GetByName(ctx, "Касса"); cat != nil {
 		catID = cat.ID
 	} else {
-		newCat := models.ExpenseCategory{Name: "Касса"}
+		newCat := models.ExpenseCategory{Name: "Касса", CompanyID: companyID, BranchID: branchID}
 		catID, _ = s.expCatSvc.Create(ctx, &newCat)
 	}
 	exp := models.Expense{

--- a/internal/services/equipment_inventory_service.go
+++ b/internal/services/equipment_inventory_service.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"time"
 
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
 )
@@ -27,11 +28,13 @@ func NewEquipmentInventoryService(r *repositories.EquipmentRepository, hr *repos
 }
 
 func (s *EquipmentInventoryService) PerformInventory(ctx context.Context, items []EquipmentInventoryItem, companyID, branchID int) error {
+	ctx = context.WithValue(ctx, common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
 	var catID int
 	if cat, _ := s.expCatSvc.GetByName(ctx, "Инвентаризация"); cat != nil {
 		catID = cat.ID
 	} else {
-		newCat := models.ExpenseCategory{Name: "Инвентаризация"}
+		newCat := models.ExpenseCategory{Name: "Инвентаризация", CompanyID: companyID, BranchID: branchID}
 		catID, _ = s.expCatSvc.Create(ctx, &newCat)
 	}
 	for _, it := range items {

--- a/internal/services/expense_category_service.go
+++ b/internal/services/expense_category_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
 )
@@ -15,6 +16,13 @@ func NewExpenseCategoryService(r *repositories.ExpenseCategoryRepository) *Expen
 }
 
 func (s *ExpenseCategoryService) Create(ctx context.Context, c *models.ExpenseCategory) (int, error) {
+	ex, err := s.repo.GetByName(ctx, c.Name)
+	if err != nil {
+		return 0, err
+	}
+	if ex != nil {
+		return 0, ErrNameExists
+	}
 	return s.repo.Create(ctx, c)
 }
 
@@ -23,6 +31,13 @@ func (s *ExpenseCategoryService) GetAll(ctx context.Context) ([]models.ExpenseCa
 }
 
 func (s *ExpenseCategoryService) Update(ctx context.Context, c *models.ExpenseCategory) error {
+	ex, err := s.repo.GetByName(ctx, c.Name)
+	if err != nil {
+		return err
+	}
+	if ex != nil && ex.ID != c.ID {
+		return ErrNameExists
+	}
 	return s.repo.Update(ctx, c)
 }
 

--- a/internal/services/inventory_service.go
+++ b/internal/services/inventory_service.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"time"
 
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
 )
@@ -27,11 +28,13 @@ func NewInventoryService(pr *repositories.PriceItemRepository, hr *repositories.
 }
 
 func (s *InventoryService) PerformInventory(ctx context.Context, items []InventoryItem) error {
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
 	var catID int
 	if cat, _ := s.expCatSvc.GetByName(ctx, "Инвентаризация"); cat != nil {
 		catID = cat.ID
 	} else {
-		newCat := models.ExpenseCategory{Name: "Инвентаризация"}
+		newCat := models.ExpenseCategory{Name: "Инвентаризация", CompanyID: companyID, BranchID: branchID}
 		catID, _ = s.expCatSvc.Create(ctx, &newCat)
 	}
 	for _, it := range items {


### PR DESCRIPTION
## Summary
- add company and branch fields to expense categories
- scope expense category queries by JWT-provided company/branch
- propagate tenant context when auto-creating expense categories

## Testing
- `go build ./...`
- `go test ./...` *(no tests found / command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_68943b166e2083249f15b40930c49bdb