### PR TITLE
Add tenant scoped expenses and repair category handling

### DIFF
--- a/internal/handlers/expense_handler.go
+++ b/internal/handlers/expense_handler.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
-	"github.com/gin-gonic/gin"
+	"context"
 	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
-	"strconv"
 )
 
 type ExpenseHandler struct {
@@ -23,7 +26,13 @@ func (h *ExpenseHandler) CreateExpense(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	id, err := h.service.CreateExpense(c.Request.Context(), &e)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	e.CompanyID = companyID
+	e.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	id, err := h.service.CreateExpense(ctx, &e)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -34,8 +43,12 @@ func (h *ExpenseHandler) CreateExpense(c *gin.Context) {
 
 // GET /api/expenses
 func (h *ExpenseHandler) GetAllExpenses(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
 	from, to, _, _ := getPeriod(c)
-	expenses, err := h.service.GetAllExpenses(c.Request.Context(), from, to)
+	expenses, err := h.service.GetAllExpenses(ctx, from, to)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -50,7 +63,11 @@ func (h *ExpenseHandler) GetExpenseByID(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	e, err := h.service.GetExpenseByID(c.Request.Context(), id)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	e, err := h.service.GetExpenseByID(ctx, id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -70,8 +87,14 @@ func (h *ExpenseHandler) UpdateExpense(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
 	e.ID = id
-	err = h.service.UpdateExpense(c.Request.Context(), &e)
+	e.CompanyID = companyID
+	e.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	err = h.service.UpdateExpense(ctx, &e)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -86,7 +109,11 @@ func (h *ExpenseHandler) DeleteExpense(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	err = h.service.DeleteExpense(c.Request.Context(), id)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	err = h.service.DeleteExpense(ctx, id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/handlers/pricelist_history_handler.go
+++ b/internal/handlers/pricelist_history_handler.go
@@ -116,7 +116,7 @@ func (h *PricelistHistoryHandler) Delete(c *gin.Context) {
 	if item != nil {
 		title := "Пополнение " + item.Name
 		desc := "Пополнение товара " + item.Name + " в количестве " + strconv.FormatFloat(hist.Quantity, 'f', -1, 64) + " шт."
-		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, desc, hist.Total, 0)
+		_ = h.expenses.DeleteByDetails(ctx, title, desc, hist.Total, 0)
 	}
 	c.Status(http.StatusNoContent)
 }

--- a/internal/handlers/repair_category_handler.go
+++ b/internal/handlers/repair_category_handler.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
 )
@@ -23,7 +25,13 @@ func (h *RepairCategoryHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	id, err := h.service.Create(c.Request.Context(), &cat)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	cat.CompanyID = companyID
+	cat.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	id, err := h.service.Create(ctx, &cat)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -33,7 +41,11 @@ func (h *RepairCategoryHandler) Create(c *gin.Context) {
 }
 
 func (h *RepairCategoryHandler) GetAll(c *gin.Context) {
-	cats, err := h.service.GetAll(c.Request.Context())
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	cats, err := h.service.GetAll(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -52,8 +64,14 @@ func (h *RepairCategoryHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
 	cat.ID = id
-	if err := h.service.Update(c.Request.Context(), &cat); err != nil {
+	cat.CompanyID = companyID
+	cat.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Update(ctx, &cat); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -66,7 +84,11 @@ func (h *RepairCategoryHandler) Delete(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Delete(ctx, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/handlers/repair_handler.go
+++ b/internal/handlers/repair_handler.go
@@ -145,8 +145,12 @@ func (h *RepairHandler) DeleteRepair(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	rep, _ := h.service.GetRepairByID(c.Request.Context(), id)
-	err = h.service.DeleteRepair(c.Request.Context(), id)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	rep, _ := h.service.GetRepairByID(ctx, id)
+	err = h.service.DeleteRepair(ctx, id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -154,7 +158,7 @@ func (h *RepairHandler) DeleteRepair(c *gin.Context) {
 
 	if rep != nil {
 		title := "Починка, номер VIN: " + rep.VIN
-		_ = h.expenses.DeleteByDetails(c.Request.Context(), title, rep.Description, rep.Price, rep.CategoryID)
+		_ = h.expenses.DeleteByDetails(ctx, title, rep.Description, rep.Price, rep.CategoryID)
 	}
 
 	c.Status(http.StatusNoContent)

--- a/internal/models/expense.go
+++ b/internal/models/expense.go
@@ -14,4 +14,6 @@ type Expense struct {
 	Description      string    `json:"description"`
 	Paid             bool      `json:"paid"`
 	CreatedAt        time.Time `json:"created_at"`
+	CompanyID        int       `json:"company_id"`
+	BranchID         int       `json:"branch_id"`
 }

--- a/internal/models/repair_category.go
+++ b/internal/models/repair_category.go
@@ -1,6 +1,8 @@
 package models
 
 type RepairCategory struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	CompanyID int    `json:"company_id"`
+	BranchID  int    `json:"branch_id"`
 }

--- a/internal/services/repair_category_service.go
+++ b/internal/services/repair_category_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/repositories"
 )
@@ -15,6 +16,13 @@ func NewRepairCategoryService(r *repositories.RepairCategoryRepository) *RepairC
 }
 
 func (s *RepairCategoryService) Create(ctx context.Context, c *models.RepairCategory) (int, error) {
+	ex, err := s.repo.GetByName(ctx, c.Name)
+	if err != nil {
+		return 0, err
+	}
+	if ex != nil {
+		return 0, ErrNameExists
+	}
 	return s.repo.Create(ctx, c)
 }
 
@@ -23,6 +31,13 @@ func (s *RepairCategoryService) GetAll(ctx context.Context) ([]models.RepairCate
 }
 
 func (s *RepairCategoryService) Update(ctx context.Context, c *models.RepairCategory) error {
+	ex, err := s.repo.GetByName(ctx, c.Name)
+	if err != nil {
+		return err
+	}
+	if ex != nil && ex.ID != c.ID {
+		return ErrNameExists
+	}
 	return s.repo.Update(ctx, c)
 }
 


### PR DESCRIPTION
## Summary
- scope expenses and repair categories by company and branch
- prevent duplicate repair category names per tenant
- propagate tenant context in related handlers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68943d55d5e083249a797dcadef4c779