### PR TITLE
Scope channel operations by company and branch

### DIFF
--- a/internal/handlers/channel_handler.go
+++ b/internal/handlers/channel_handler.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 	"psclub-crm/internal/services"
 )
@@ -23,7 +25,13 @@ func (h *ChannelHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	id, err := h.service.Create(c.Request.Context(), &ch)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ch.CompanyID = companyID
+	ch.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	id, err := h.service.Create(ctx, &ch)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -33,7 +41,11 @@ func (h *ChannelHandler) Create(c *gin.Context) {
 }
 
 func (h *ChannelHandler) GetAll(c *gin.Context) {
-	list, err := h.service.GetAll(c.Request.Context())
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	list, err := h.service.GetAll(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -52,8 +64,14 @@ func (h *ChannelHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
 	ch.ID = id
-	if err := h.service.Update(c.Request.Context(), &ch); err != nil {
+	ch.CompanyID = companyID
+	ch.BranchID = branchID
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Update(ctx, &ch); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -66,7 +84,11 @@ func (h *ChannelHandler) Delete(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	if err := h.service.Delete(ctx, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -79,7 +101,11 @@ func (h *ChannelHandler) GetByID(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	ch, err := h.service.GetByID(c.Request.Context(), id)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
+	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
+	ch, err := h.service.GetByID(ctx, id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return

--- a/internal/models/channel.go
+++ b/internal/models/channel.go
@@ -1,6 +1,8 @@
 package models
 
 type Channel struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID        int    `json:"id"`
+	CompanyID int    `json:"company_id"`
+	BranchID  int    `json:"branch_id"`
+	Name      string `json:"name"`
 }

--- a/internal/repositories/settings_repository.go
+++ b/internal/repositories/settings_repository.go
@@ -49,7 +49,7 @@ func (r *SettingsRepository) Get(ctx context.Context, companyID, branchID int) (
 	s.PaymentTypes = types
 
 	// Получить список всех channels
-	chQuery := `SELECT id, name FROM channels WHERE company_id=? AND branch_id=? ORDER BY id`
+	chQuery := `SELECT id, company_id, branch_id, name FROM channels WHERE company_id=? AND branch_id=? ORDER BY id`
 	chRows, err := r.db.QueryContext(ctx, chQuery, companyID, branchID)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (r *SettingsRepository) Get(ctx context.Context, companyID, branchID int) (
 	var channels []models.Channel
 	for chRows.Next() {
 		var ch models.Channel
-		if err := chRows.Scan(&ch.ID, &ch.Name); err != nil {
+		if err := chRows.Scan(&ch.ID, &ch.CompanyID, &ch.BranchID, &ch.Name); err != nil {
 			return nil, err
 		}
 		channels = append(channels, ch)


### PR DESCRIPTION
## Summary
- add company_id and branch_id fields to Channel model
- use JWT claims to scope channel CRUD operations to a tenant
- load tenant-aware channels in settings repository

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689442d1e64083249dd97b6fd49ebc72