### PR TITLE
Scope cashbox and repair repos by company and branch

### DIFF
--- a/internal/repositories/cashbox_repository.go
+++ b/internal/repositories/cashbox_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"context"
 	"database/sql"
+
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 )
 
@@ -15,9 +17,11 @@ func NewCashboxRepository(db *sql.DB) *CashboxRepository {
 }
 
 func (r *CashboxRepository) Get(ctx context.Context) (*models.Cashbox, error) {
-	query := `SELECT id, amount FROM cashbox LIMIT 1`
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
+	query := `SELECT id, amount FROM cashbox WHERE company_id=? AND branch_id=? LIMIT 1`
 	var c models.Cashbox
-	err := r.db.QueryRowContext(ctx, query).Scan(&c.ID, &c.Amount)
+	err := r.db.QueryRowContext(ctx, query, companyID, branchID).Scan(&c.ID, &c.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +29,9 @@ func (r *CashboxRepository) Get(ctx context.Context) (*models.Cashbox, error) {
 }
 
 func (r *CashboxRepository) Update(ctx context.Context, c *models.Cashbox) error {
-	query := `UPDATE cashbox SET amount=? WHERE id=?`
-	_, err := r.db.ExecContext(ctx, query, c.Amount, c.ID)
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
+	query := `UPDATE cashbox SET amount=? WHERE id=? AND company_id=? AND branch_id=?`
+	_, err := r.db.ExecContext(ctx, query, c.Amount, c.ID, companyID, branchID)
 	return err
 }

--- a/internal/repositories/repair_repository.go
+++ b/internal/repositories/repair_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"context"
 	"database/sql"
+
+	"psclub-crm/internal/common"
 	"psclub-crm/internal/models"
 )
 
@@ -15,9 +17,11 @@ func NewRepairRepository(db *sql.DB) *RepairRepository {
 }
 
 func (r *RepairRepository) Create(ctx context.Context, rep *models.Repair) (int, error) {
-	query := `INSERT INTO repairs (date, vin, description, price, category_id, created_at, updated_at)
-                VALUES (?, ?, ?, ?, NULLIF(?,0), NOW(), NOW())`
-	res, err := r.db.ExecContext(ctx, query, rep.Date, rep.VIN, rep.Description, rep.Price, rep.CategoryID)
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
+	query := `INSERT INTO repairs (date, vin, description, price, category_id, created_at, updated_at, company_id, branch_id)
+                VALUES (?, ?, ?, ?, NULLIF(?,0), NOW(), NOW(), ?, ?)`
+	res, err := r.db.ExecContext(ctx, query, rep.Date, rep.VIN, rep.Description, rep.Price, rep.CategoryID, companyID, branchID)
 	if err != nil {
 		return 0, err
 	}
@@ -26,11 +30,14 @@ func (r *RepairRepository) Create(ctx context.Context, rep *models.Repair) (int,
 }
 
 func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) {
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
 	query := `SELECT r.id, r.date, r.vin, r.description, r.price, IFNULL(r.category_id, 0), IFNULL(rc.name, ''), r.created_at, r.updated_at
                 FROM repairs r
                 LEFT JOIN repair_categories rc ON r.category_id = rc.id
+                WHERE r.company_id=? AND r.branch_id=?
                 ORDER BY r.id DESC`
-	rows, err := r.db.QueryContext(ctx, query)
+	rows, err := r.db.QueryContext(ctx, query, companyID, branchID)
 	if err != nil {
 		return nil, err
 	}
@@ -48,12 +55,14 @@ func (r *RepairRepository) GetAll(ctx context.Context) ([]models.Repair, error) 
 }
 
 func (r *RepairRepository) GetByID(ctx context.Context, id int) (*models.Repair, error) {
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
 	query := `SELECT r.id, r.date, r.vin, r.description, r.price, IFNULL(r.category_id, 0), IFNULL(rc.name,''), r.created_at, r.updated_at
                 FROM repairs r
                 LEFT JOIN repair_categories rc ON r.category_id = rc.id
-                WHERE r.id = ?`
+                WHERE r.id = ? AND r.company_id=? AND r.branch_id=?`
 	var rep models.Repair
-	err := r.db.QueryRowContext(ctx, query, id).Scan(&rep.ID, &rep.Date, &rep.VIN, &rep.Description, &rep.Price, &rep.CategoryID, &rep.Category, &rep.CreatedAt, &rep.UpdatedAt)
+	err := r.db.QueryRowContext(ctx, query, id, companyID, branchID).Scan(&rep.ID, &rep.Date, &rep.VIN, &rep.Description, &rep.Price, &rep.CategoryID, &rep.Category, &rep.CreatedAt, &rep.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +70,16 @@ func (r *RepairRepository) GetByID(ctx context.Context, id int) (*models.Repair,
 }
 
 func (r *RepairRepository) Update(ctx context.Context, rep *models.Repair) error {
-	query := `UPDATE repairs SET date = ?, vin = ?, description = ?, price = ?, category_id=NULLIF(?,0), updated_at = NOW() WHERE id = ?`
-	_, err := r.db.ExecContext(ctx, query, rep.Date, rep.VIN, rep.Description, rep.Price, rep.CategoryID, rep.ID)
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
+	query := `UPDATE repairs SET date = ?, vin = ?, description = ?, price = ?, category_id=NULLIF(?,0), updated_at = NOW() WHERE id = ? AND company_id=? AND branch_id=?`
+	_, err := r.db.ExecContext(ctx, query, rep.Date, rep.VIN, rep.Description, rep.Price, rep.CategoryID, rep.ID, companyID, branchID)
 	return err
 }
 
 func (r *RepairRepository) Delete(ctx context.Context, id int) error {
-	_, err := r.db.ExecContext(ctx, `DELETE FROM repairs WHERE id = ?`, id)
+	companyID := ctx.Value(common.CtxCompanyID).(int)
+	branchID := ctx.Value(common.CtxBranchID).(int)
+	_, err := r.db.ExecContext(ctx, `DELETE FROM repairs WHERE id = ? AND company_id=? AND branch_id=?`, id, companyID, branchID)
 	return err
 }


### PR DESCRIPTION
## Summary
- require company_id and branch_id when reading or updating the cashbox
- ensure repair records are created, fetched, updated and deleted with company and branch scoping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68948d36aa648324bfbe70b93842f81c