### PR TITLE
Fix column-value mismatch in booking creation

### DIFF
--- a/internal/repositories/booking_repository.go
+++ b/internal/repositories/booking_repository.go
@@ -30,7 +30,7 @@ func (r *BookingRepository) CreateWithItems(ctx context.Context, companyID, bran
 	}()
 
 	query := `INSERT INTO bookings (company_id, branch_id, client_id, table_id, user_id, start_time, end_time, note, discount, discount_reason, total_amount, bonus_used, payment_status, payment_type_id, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())`
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())`
 
 	var clientID interface{}
 	if b.ClientID > 0 {


### PR DESCRIPTION
## Summary
- prevent `Error 1136 (21S01)` by aligning value placeholders with columns in booking insert query

## Testing
- `go test ./...` *(fails: command hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68949059a3988324954809745f453e38