### PR TITLE
Fix cashbox updates on booking changes

### DIFF
--- a/internal/services/booking_service.go
+++ b/internal/services/booking_service.go
@@ -272,6 +272,7 @@ func (s *BookingService) UpdateBooking(ctx context.Context, b *models.Booking) e
 	}
 	currentItems, _ := s.bookingItemRepo.GetByBookingID(ctx, companyID, branchID, b.ID)
 	currentPays, _ := s.paymentRepo.GetByBookingID(ctx, companyID, branchID, b.ID)
+	current.Payments = currentPays
 
 	equal := bookingsEqual(current, b, currentItems)
 	if equal && len(currentPays) == len(b.Payments) {
@@ -352,6 +353,8 @@ func (s *BookingService) DeleteBooking(ctx context.Context, id int) error {
 	if err != nil {
 		return err
 	}
+	pays, _ := s.paymentRepo.GetByBookingID(ctx, companyID, branchID, id)
+	b.Payments = pays
 	if s.isPastDayBlocked(b.StartTime, settings.BlockTime) {
 		return errors.New("booking can no longer be removed")
 	}


### PR DESCRIPTION
## Summary
- ensure cashbox history and balance update when bookings are modified or deleted

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68949c2dcac083248e57a39d2408fad1