### PR TITLE
Add table reports endpoint

### DIFF
--- a/internal/handlers/report_handler.go
+++ b/internal/handlers/report_handler.go
@@ -81,6 +81,19 @@ func (h *ReportHandler) GetDiscountsReport(c *gin.Context) {
 	c.JSON(http.StatusOK, data)
 }
 
+func (h *ReportHandler) GetTablesReport(c *gin.Context) {
+	from, to, tFrom, tTo := getPeriod(c)
+	userID := getUserID(c)
+	companyID := c.GetInt("company_id")
+	branchID := c.GetInt("branch_id")
+	data, err := h.service.TablesReport(c.Request.Context(), from, to, tFrom, tTo, userID, companyID, branchID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, data)
+}
+
 func getPeriod(c *gin.Context) (from, to time.Time, tFrom, tTo string) {
 	layoutDate := "2006-01-02"
 	fromStr := c.DefaultQuery("from", time.Now().AddDate(0, 0, -7).Format(layoutDate))

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -120,3 +120,15 @@ type ChannelStat struct {
 	Channel string `json:"channel"`
 	Clients int    `json:"clients"`
 }
+
+type TableReport struct {
+	TableID           int              `json:"table_id"`
+	TableName         string           `json:"table_name"`
+	Total             float64          `json:"total"`
+	TotalRevenue      float64          `json:"total_revenue"`
+	AvgCheck          float64          `json:"avg_check"`
+	LoadPercent       float64          `json:"load_percent"`
+	Visits            float64          `json:"visits"`
+	PaymentTypeIncome []CategoryIncome `json:"income_by_payment_type"`
+	TotalCost         float64          `json:"total_cost"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -257,6 +257,7 @@ func SetupRoutes(
 		reports.GET("/admins", reportHandler.GetAdminsReport)
 		reports.GET("/sales", reportHandler.GetSalesReport)
 		reports.GET("/analytics", reportHandler.GetAnalyticsReport)
+		reports.GET("/tables", reportHandler.GetTablesReport)
 		reports.GET("/discounts", reportHandler.GetDiscountsReport)
 	}
 }

--- a/internal/services/report_service.go
+++ b/internal/services/report_service.go
@@ -30,3 +30,7 @@ func (s *ReportService) AnalyticsReport(ctx context.Context, from, to time.Time,
 func (s *ReportService) DiscountsReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID, companyID, branchID int) (*models.DiscountsReport, error) {
 	return s.repo.DiscountsReport(ctx, from, to, tFrom, tTo, userID, companyID, branchID)
 }
+
+func (s *ReportService) TablesReport(ctx context.Context, from, to time.Time, tFrom, tTo string, userID, companyID, branchID int) ([]models.TableReport, error) {
+	return s.repo.TablesReport(ctx, from, to, tFrom, tTo, userID, companyID, branchID)
+}


### PR DESCRIPTION
## Summary
- add TableReport model and repository method to aggregate per-table stats
- expose /api/reports/tables endpoint returning table revenue, avg check, load, visits, payment type income, and cost

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895a8c0246c8324a867a3dec4c58b45