### PR TITLE
Add default data creation for new companies

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -159,6 +159,20 @@ func Run() {
 	reportService := services.NewReportService(reportRepo)
 	reportHandler := handlers.NewReportHandler(reportService)
 
+	// Компании
+	companyRepo := repositories.NewCompanyRepository(db)
+	companyService := services.NewCompanyService(
+		companyRepo,
+		channelRepo,
+		tableCategoryRepo,
+		tableRepo,
+		categoryRepo,
+		paymentTypeRepo,
+		settingsRepo,
+		expCatRepo,
+	)
+	companyHandler := handlers.NewCompanyHandler(companyService)
+
 	// ========== Роутер и middlewares ==========
 	router := gin.New()
 	router.Use(middleware.RequestLogger())
@@ -167,6 +181,7 @@ func Run() {
 	routes.SetupRoutes(
 		router,
 		authHandler,
+		companyHandler,
 		clientHandler,
 		channelHandler,
 		userHandler,

--- a/internal/handlers/company_handler.go
+++ b/internal/handlers/company_handler.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"psclub-crm/internal/services"
+)
+
+type CompanyHandler struct {
+	service *services.CompanyService
+}
+
+func NewCompanyHandler(s *services.CompanyService) *CompanyHandler {
+	return &CompanyHandler{service: s}
+}
+
+type createCompanyRequest struct {
+	Name       string `json:"name"`
+	BranchName string `json:"branch_name"`
+}
+
+func (h *CompanyHandler) Create(c *gin.Context) {
+	var req createCompanyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	companyID, branchID, err := h.service.CreateCompany(c.Request.Context(), req.Name, req.BranchName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"company_id": companyID, "branch_id": branchID})
+}

--- a/internal/models/company.go
+++ b/internal/models/company.go
@@ -1,0 +1,12 @@
+package models
+
+type Company struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type Branch struct {
+	ID        int    `json:"id"`
+	CompanyID int    `json:"company_id"`
+	Name      string `json:"name"`
+}

--- a/internal/repositories/company_repository.go
+++ b/internal/repositories/company_repository.go
@@ -1,0 +1,32 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+)
+
+type CompanyRepository struct {
+	db *sql.DB
+}
+
+func NewCompanyRepository(db *sql.DB) *CompanyRepository {
+	return &CompanyRepository{db: db}
+}
+
+func (r *CompanyRepository) CreateCompany(ctx context.Context, name string) (int, error) {
+	res, err := r.db.ExecContext(ctx, `INSERT INTO companies (name) VALUES (?)`, name)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}
+
+func (r *CompanyRepository) CreateBranch(ctx context.Context, companyID int, name string) (int, error) {
+	res, err := r.db.ExecContext(ctx, `INSERT INTO branches (company_id, name) VALUES (?, ?)`, companyID, name)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	return int(id), err
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -9,6 +9,7 @@ import (
 func SetupRoutes(
 	r *gin.Engine,
 	authHandler *handlers.AuthHandler,
+	companyHandler *handlers.CompanyHandler,
 	clientHandler *handlers.ClientHandler,
 	channelHandler *handlers.ChannelHandler,
 	userHandler *handlers.UserHandler,
@@ -40,6 +41,11 @@ func SetupRoutes(
 		auth.POST("/register", authHandler.Register)
 		auth.POST("/login", authHandler.Login)
 		auth.POST("/refresh", authHandler.Refresh)
+	}
+
+	companies := api.Group("/companies")
+	{
+		companies.POST("", companyHandler.Create)
 	}
 
 	api.Use(middleware.Auth(authSecret))

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -1,0 +1,116 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"psclub-crm/internal/common"
+	"psclub-crm/internal/models"
+	"psclub-crm/internal/repositories"
+)
+
+type CompanyService struct {
+	repo            *repositories.CompanyRepository
+	channelRepo     *repositories.ChannelRepository
+	tableCatRepo    *repositories.TableCategoryRepository
+	tableRepo       *repositories.TableRepository
+	categoryRepo    *repositories.CategoryRepository
+	paymentTypeRepo *repositories.PaymentTypeRepository
+	settingsRepo    *repositories.SettingsRepository
+	expenseCatRepo  *repositories.ExpenseCategoryRepository
+}
+
+func NewCompanyService(
+	repo *repositories.CompanyRepository,
+	channelRepo *repositories.ChannelRepository,
+	tableCatRepo *repositories.TableCategoryRepository,
+	tableRepo *repositories.TableRepository,
+	categoryRepo *repositories.CategoryRepository,
+	paymentTypeRepo *repositories.PaymentTypeRepository,
+	settingsRepo *repositories.SettingsRepository,
+	expenseCatRepo *repositories.ExpenseCategoryRepository,
+) *CompanyService {
+	return &CompanyService{
+		repo:            repo,
+		channelRepo:     channelRepo,
+		tableCatRepo:    tableCatRepo,
+		tableRepo:       tableRepo,
+		categoryRepo:    categoryRepo,
+		paymentTypeRepo: paymentTypeRepo,
+		settingsRepo:    settingsRepo,
+		expenseCatRepo:  expenseCatRepo,
+	}
+}
+
+type CreateCompanyInput struct {
+	Name       string
+	BranchName string
+}
+
+func (s *CompanyService) CreateCompany(ctx context.Context, name, branchName string) (int, int, error) {
+	companyID, err := s.repo.CreateCompany(ctx, name)
+	if err != nil {
+		return 0, 0, err
+	}
+	branchID, err := s.repo.CreateBranch(ctx, companyID, branchName)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	tenantCtx := context.WithValue(ctx, common.CtxCompanyID, companyID)
+	tenantCtx = context.WithValue(tenantCtx, common.CtxBranchID, branchID)
+
+	if _, err := s.channelRepo.Create(tenantCtx, &models.Channel{Name: "- не указано"}); err != nil {
+		return 0, 0, err
+	}
+
+	tableCatID, err := s.tableCatRepo.Create(tenantCtx, &models.TableCategory{Name: "Основной зал", CompanyID: companyID, BranchID: branchID})
+	if err != nil {
+		return 0, 0, err
+	}
+	for i := 1; i <= 6; i++ {
+		if _, err := s.tableRepo.Create(tenantCtx, &models.Table{CategoryID: tableCatID, Name: fmt.Sprintf("Стол %d", i), CompanyID: companyID, BranchID: branchID}); err != nil {
+			return 0, 0, err
+		}
+	}
+
+	for _, c := range []string{"Бар", "Кальян", "Сеты", "Часы"} {
+		if _, err := s.categoryRepo.Create(tenantCtx, &models.Category{Name: c, CompanyID: companyID, BranchID: branchID}); err != nil {
+			return 0, 0, err
+		}
+	}
+
+	paymentNames := []string{"Наличными", "Картой", "Каспи QR"}
+	firstPTID := 0
+	for i, p := range paymentNames {
+		id, err := s.paymentTypeRepo.Create(tenantCtx, &models.PaymentType{Name: p, HoldPercent: 0})
+		if err != nil {
+			return 0, 0, err
+		}
+		if i == 0 {
+			firstPTID = id
+		}
+	}
+
+	for _, e := range []string{"Бар", "Кальян", "Ремонт", "Инвентаризация", "Зарплата", "Касса"} {
+		if _, err := s.expenseCatRepo.Create(tenantCtx, &models.ExpenseCategory{Name: e}); err != nil {
+			return 0, 0, err
+		}
+	}
+
+	if _, err := s.settingsRepo.Create(tenantCtx, &models.Settings{
+		PaymentType:      firstPTID,
+		BlockTime:        120,
+		BonusPercent:     0,
+		WorkTimeFrom:     "10:00",
+		WorkTimeTo:       "23:00",
+		TablesCount:      6,
+		NotificationTime: 5,
+		CompanyID:        companyID,
+		BranchID:         branchID,
+	}); err != nil {
+		return 0, 0, err
+	}
+
+	return companyID, branchID, nil
+}


### PR DESCRIPTION
## Summary
- add CompanyService, repository, handler and model
- seed default channels, tables, categories, payment types, settings and expense categories when creating a company
- expose POST /api/companies for creating companies with defaults

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689722d5397c832497ce07d13c8e4aa6