### PR TITLE
Search pricelist history by category name

### DIFF
--- a/internal/handlers/pricelist_history_handler.go
+++ b/internal/handlers/pricelist_history_handler.go
@@ -75,17 +75,17 @@ func (h *PricelistHistoryHandler) GetByItem(c *gin.Context) {
 	c.JSON(http.StatusOK, history)
 }
 
-func (h *PricelistHistoryHandler) GetByCategory(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+func (h *PricelistHistoryHandler) GetByCategoryName(c *gin.Context) {
+	name := c.Param("name")
+	if name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid name"})
 		return
 	}
 	companyID := c.GetInt("company_id")
 	branchID := c.GetInt("branch_id")
 	ctx := context.WithValue(c.Request.Context(), common.CtxCompanyID, companyID)
 	ctx = context.WithValue(ctx, common.CtxBranchID, branchID)
-	history, err := h.service.GetPricelistHistoryByCategory(ctx, id)
+	history, err := h.service.GetPricelistHistoryByCategoryName(ctx, name)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -171,7 +171,7 @@ func SetupRoutes(
 		plHistory.POST("", pricelistHistoryHandler.Create)
 		plHistory.GET("", pricelistHistoryHandler.GetAll)
 		plHistory.GET("/item/:id", pricelistHistoryHandler.GetByItem)
-		plHistory.GET("/category/:id", pricelistHistoryHandler.GetByCategory)
+		plHistory.GET("/category/name/:name", pricelistHistoryHandler.GetByCategoryName)
 		plHistory.DELETE("/:id", pricelistHistoryHandler.Delete)
 
 	}

--- a/internal/services/price_item_service.go
+++ b/internal/services/price_item_service.go
@@ -121,6 +121,10 @@ func (s *PriceItemService) GetPricelistHistoryByCategory(ctx context.Context, ca
 	return s.plHistoryRepo.GetByCategory(ctx, categoryID)
 }
 
+func (s *PriceItemService) GetPricelistHistoryByCategoryName(ctx context.Context, categoryName string) ([]models.PricelistHistory, error) {
+	return s.plHistoryRepo.GetByCategoryName(ctx, categoryName)
+}
+
 // GetAllPricelistHistory returns all replenish records
 func (s *PriceItemService) GetAllPricelistHistory(ctx context.Context) ([]models.PricelistHistory, error) {
 	return s.plHistoryRepo.GetAll(ctx)


### PR DESCRIPTION
## Summary
- allow fetching pricelist history by category name instead of numeric id
- add service and repository helpers for category name lookups
- wire new handler and route `/pricelist-history/category/name/:name`

## Testing
- `go test ./internal/services 2>&1 | head -n 20`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899aee9c5308324b52245a7674e53d5