### PR TITLE
Ensure refresh token rotation removes old tokens

### DIFF
--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -119,6 +119,9 @@ func (s *AuthService) generateTokenPair(ctx context.Context, u *models.User) (st
 	}
 	hash := s.hashToken(refreshRaw)
 	exp := time.Now().Add(s.refreshTTL)
+	if err := s.tokenRepo.DeleteByUser(ctx, u.ID); err != nil {
+		return "", "", err
+	}
 	if err := s.tokenRepo.Save(ctx, u.ID, hash, exp); err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
## Summary
- Delete existing refresh tokens for a user before saving a new one, preventing quick logouts

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac542c63948324b0a98c5384f7bdd9