### PR TITLE
Adjust cashbox day calculation based on operation

### DIFF
--- a/internal/services/cashbox_service.go
+++ b/internal/services/cashbox_service.go
@@ -195,11 +195,17 @@ func (s *CashboxService) GetDay(ctx context.Context) (float64, []models.CashboxH
 		return 0, nil, err
 	}
 
-	var sum float64
+	startAmount := box.Amount
 	for _, h := range list {
-		sum += h.Amount
+		switch h.Operation {
+		case "Пополнение", "Инвентаризация":
+			startAmount += h.Amount
+		case "Оплата брони", "Возврат брони":
+			startAmount -= h.Amount
+		default:
+			startAmount -= h.Amount
+		}
 	}
 
-	startAmount := box.Amount - sum
 	return startAmount, list, nil
 }


### PR DESCRIPTION
## Summary
- adjust the cashbox day start amount calculation to account for operation types
- add operation-specific handling for payments, replenishments, inventory, and refunds

## Testing
- not run (tests hang due to external dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d98d0fecf083248065e7c6c27e9225