### PR TITLE
Ensure auto-created expenses are marked paid

### DIFF
--- a/internal/handlers/price_item_handler.go
+++ b/internal/handlers/price_item_handler.go
@@ -312,7 +312,7 @@ func (h *PriceItemHandler) Replenish(c *gin.Context) {
 		Date:        time.Now(),
 		Title:       "Пополнение " + item.Name,
 		Total:       hist.Total,
-		Paid:        false,
+		Paid:        true,
 		CategoryID:  expCatID,
 		Description: "Пополнение товара " + item.Name + " в количестве " + strconv.FormatFloat(in.Quantity, 'f', -1, 64) + " шт.",
 	}

--- a/internal/handlers/repair_handler.go
+++ b/internal/handlers/repair_handler.go
@@ -53,7 +53,7 @@ func (h *RepairHandler) CreateRepair(c *gin.Context) {
 		Title:            "Починка, номер VIN: " + rep.VIN,
 		Total:            rep.Price,
 		Description:      rep.Description,
-		Paid:             false,
+		Paid:             true,
 		CategoryID:       catID,
 		RepairCategoryID: rep.CategoryID,
 	}
@@ -137,7 +137,7 @@ func (h *RepairHandler) UpdateRepair(c *gin.Context) {
 		Title:            "Починка, номер VIN: " + rep.VIN,
 		Total:            rep.Price,
 		Description:      rep.Description,
-		Paid:             false,
+		Paid:             true,
 		CategoryID:       catID,
 		RepairCategoryID: rep.CategoryID,
 	}

--- a/internal/services/cashbox_service.go
+++ b/internal/services/cashbox_service.go
@@ -132,7 +132,7 @@ func (s *CashboxService) Replenish(ctx context.Context, amount float64) error {
 		Date:       time.Now(),
 		Title:      "Пополнение кассы",
 		Total:      amount,
-		Paid:       false,
+		Paid:       true,
 		CategoryID: catID,
 	}
 	_, _ = s.expenseSvc.CreateExpense(ctx, &exp)

--- a/internal/services/equipment_inventory_service.go
+++ b/internal/services/equipment_inventory_service.go
@@ -61,7 +61,7 @@ func (s *EquipmentInventoryService) PerformInventory(ctx context.Context, items 
 				Title:       "Инвентаризация: " + eq.Name,
 				Total:       0,
 				Description: "Недостача оборудования " + eq.Name + " (" + fmt.Sprintf("%.0f", math.Abs(diff)) + " шт.)",
-				Paid:        false,
+				Paid:        true,
 				CategoryID:  catID,
 			}
 			if _, err := s.expenseSvc.CreateExpense(ctx, &exp); err != nil {

--- a/internal/services/inventory_service.go
+++ b/internal/services/inventory_service.go
@@ -60,7 +60,7 @@ func (s *InventoryService) PerformInventory(ctx context.Context, items []Invento
 				Title:       "Инвентаризация: " + pi.Name,
 				Total:       -diff * pi.BuyPrice,
 				Description: "Недостача товара " + pi.Name + " (" + fmt.Sprintf("%.0f", math.Abs(diff)) + " шт.)",
-				Paid:        false,
+				Paid:        true,
 				CategoryID:  catID,
 			}
 			if _, err := s.expenseSvc.CreateExpense(ctx, &exp); err != nil {


### PR DESCRIPTION
## Summary
- mark automatically generated expense records as paid across handlers and services
- keep manual /api/expenses POST endpoint behavior unchanged

## Testing
- go test ./... *(hangs due to external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68da43873fb8832483bd71fa1b3e1965